### PR TITLE
Add the dependency analyser with the go toolchain to kraft.

### DIFF
--- a/kraft/commands/__init__.py
+++ b/kraft/commands/__init__.py
@@ -38,6 +38,7 @@ from .configure import configure
 from .init import init
 from .lib.bump import bump as libbump
 from .lib.init import init as libinit
+from .devel.dependency import dependency as develdependency
 from .list import list
 from .run import run
 from .up import up

--- a/kraft/commands/devel/dependency.py
+++ b/kraft/commands/devel/dependency.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Authors: Gaulthier Gain <gaulthier.gain@uliege.be>
+#
+# Copyright (c) 2020, NEC Europe Ltd., NEC Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+import sys
+
+import click
+
+from kraft.commands.list import update
+from kraft.components.library import Library
+from kraft.components.types import RepositoryType
+from kraft.context import kraft_context
+from kraft.errors import KraftError
+from kraft.logger import logger
+from kraft.utils import op, dir
+
+import os
+import subprocess
+
+TOOLCHAIN_PATH = 'tools'
+TOOLCHAIN_URL_GIT = 'https://github.com/gaulthiergain/tools.git'
+
+def init_toolchain():
+    """
+    Set up the golang environment as well as the toolchain.
+    """
+
+    # Check if go is installed
+    if not op.is_software_installed("go"):
+        logger.debug("Go is not installed. Installing and setup.")
+        op.execute_command("./scripts/install_go.sh")
+
+    # Check if the toolchain is installed
+    go_src_path = os.path.join(dir.get_home_dir(), 'go', 'src')
+    toolchain_path = os.path.join(go_src_path, TOOLCHAIN_PATH)
+    if not dir.existing_path(toolchain_path):
+        os.chdir(go_src_path)
+        op.execute_command('git', ['clone', TOOLCHAIN_URL_GIT])
+    
+    # Change to the toolchain repo
+    os.chdir(toolchain_path)
+    op.execute_command('git', ['checkout', 'staging'])
+    op.execute_command('git', ['pull'])
+    os.chdir(os.path.join(toolchain_path, 'srcs'))
+    op.execute_command('make')
+
+@click.command('dependency', short_help='Gather the dependencies of a specific application.', context_settings=dict(
+    ignore_unknown_options=True, 
+    allow_extra_args=True))  # noqa: C901
+@click.pass_context
+def dependency(ctx):
+    """
+    Gather the dependencies of a specific application.
+    """
+    
+    try:
+        # Init the toolchain environment
+        init_toolchain()
+        # Execute the toolchain with unparsed arguments 
+        op.execute_command('./tools', ctx.args)
+    
+    except KraftError as e:
+        logger.critical(e)
+        sys.exit(1)

--- a/kraft/kraft.py
+++ b/kraft/kraft.py
@@ -36,6 +36,7 @@ import click
 from kraft.commands import build
 from kraft.commands import clean
 from kraft.commands import configure
+from kraft.commands import develdependency
 from kraft.commands import init
 from kraft.commands import libbump
 from kraft.commands import libinit
@@ -87,9 +88,19 @@ def lib(ctx):
     """
     pass
 
+@click.group(name='devel', short_help='Unikraft devel commands.')
+@kraft_context
+def devel(ctx):
+    """
+    Unikraft developer sub-commands useful for maintaing and working
+    directly with Unikraft source code.
+    """
+    pass
 
 lib.add_command(libinit)
 lib.add_command(libbump)
+
+devel.add_command(develdependency)
 
 kraft.add_command(up)
 kraft.add_command(run)
@@ -99,3 +110,4 @@ kraft.add_command(build)
 kraft.add_command(clean)
 kraft.add_command(configure)
 kraft.add_command(lib)
+kraft.add_command(devel)

--- a/kraft/utils/dir.py
+++ b/kraft/utils/dir.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # Authors: Alexander Jung <alexander.jung@neclab.eu>
+#          Gaulthier Gain <gaulthier.gain@uliege.be>
 #
 # Copyright (c) 2020, NEC Europe Ltd., NEC Corporation. All rights reserved.
 #
@@ -35,9 +36,17 @@ import os
 import shutil
 from shutil import copyfile
 from shutil import SameFileError
+from pathlib import Path
 
 from kraft.logger import logger
 
+def existing_path(path):
+    """Return a boolean of whether the provided `path` exists."""
+    return os.path.exists(path)  
+
+def get_home_dir():
+    """Return a string which represents the current home directory."""
+    return str(Path.home())
 
 def is_dir_empty(path=None):
     """Return a boolean of whether the provided directory `dir` is empty."""

--- a/kraft/utils/op.py
+++ b/kraft/utils/op.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # Authors: Alexander Jung <alexander.jung@neclab.eu>
+#          Gaulthier Gain <gaulthier.gain@uliege.be>
 #
 # Copyright (c) 2020, NEC Europe Ltd., NEC Corporation. All rights reserved.
 #
@@ -32,10 +33,22 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os
+import shlex
 import subprocess
 
 from kraft.logger import logger
 
+def execute_command(command, parameters=' '):
+    """Run a specific command on the host."""
+    subprocess.call(shlex.split(command + ' ' + ' '.join(parameters)))
+
+
+def is_software_installed(program):
+    """Check if a program/software is installed on the host."""
+    rc = subprocess.call(['which', program], stdout=subprocess.DEVNULL)
+    if rc == 0:
+        return True
+    return False
 
 def merge_dicts(x, y):
     z = x.copy()

--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Authors: Gaulthier Gain <gaulthier.gain@uliege.be>
+#
+# Copyright (c) 2020, NEC Europe Ltd., NEC Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+set -e
+
+VERSION="1.14.4"
+
+[ -z "$GOROOT" ] && GOROOT="/usr/lib/go-$VERSION"
+[ -z "$GOPATH" ] && GOPATH="$HOME/go"
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case $OS in
+    "Linux")
+        case $ARCH in
+        "x86_64")
+            ARCH=amd64
+            ;;
+        "aarch64")
+            ARCH=arm64
+            ;;
+        "armv6")
+            ARCH=armv6l
+            ;;
+        "armv8")
+            ARCH=arm64
+            ;;
+        .*386.*)
+            ARCH=386
+            ;;
+        esac
+        PLATFORM="linux-$ARCH"
+    ;;
+    "Darwin")
+        PLATFORM="darwin-amd64"
+    ;;
+esac
+
+print_help() {
+    echo "Usage: bash goinstall.sh [OPTIONS]"
+    echo -e "\nOPTIONS:"
+    echo -e "  --remove\tRemove currently installed version"
+    echo -e "  --version\tSpecify a version number to install"
+}
+
+if [ -n "`$SHELL -c 'echo $ZSH_VERSION'`" ]; then
+    shell_profile="zshrc"
+elif [ -n "`$SHELL -c 'echo $BASH_VERSION'`" ]; then
+    shell_profile="bashrc"
+fi
+
+if [ "$1" == "--remove" ]; then
+    sudo rm -rf "$GOROOT"
+    if [ "$OS" == "Darwin" ]; then
+        sed -i "" '/# GoLang/d' "$HOME/.${shell_profile}"
+        sed -i "" '/export GOROOT/d' "$HOME/.${shell_profile}"
+        sed -i "" '/$GOROOT\/bin/d' "$HOME/.${shell_profile}"
+        sed -i "" '/export GOPATH/d' "$HOME/.${shell_profile}"
+        sed -i "" '/$GOPATH\/bin/d' "$HOME/.${shell_profile}"
+    else
+        sed -i '/# GoLang/d' "$HOME/.${shell_profile}"
+        sed -i '/export GOROOT/d' "$HOME/.${shell_profile}"
+        sed -i '/$GOROOT\/bin/d' "$HOME/.${shell_profile}"
+        sed -i '/export GOPATH/d' "$HOME/.${shell_profile}"
+        sed -i '/$GOPATH\/bin/d' "$HOME/.${shell_profile}"
+    fi
+    echo "Go removed."
+    exit 0
+elif [ "$1" == "--help" ]; then
+    print_help
+    exit 0
+elif [ "$1" == "--version" ]; then
+    if [ -z "$2" ]; then # Check if --version has a second positional parameter
+        echo "Please provide a version number for: $1"
+    else
+        VERSION=$2
+    fi
+elif [ ! -z "$1" ]; then
+    echo "Unrecognized option: $1"
+    exit 1
+fi
+
+if [ -d "$GOROOT" ]; then
+    echo "The Go install directory ($GOROOT) already exists. Exiting."
+    exit 1
+fi
+
+PACKAGE_NAME="go$VERSION.$PLATFORM.tar.gz"
+TEMP_DIRECTORY=$(mktemp -d)
+
+echo "Downloading $PACKAGE_NAME ..."
+if hash wget 2>/dev/null; then
+    wget https://golang.org/dl/$PACKAGE_NAME -O "$TEMP_DIRECTORY/go.tar.gz"
+else
+    curl -o "$TEMP_DIRECTORY/go.tar.gz" https://golang.org/dl/$PACKAGE_NAME
+fi
+
+if [ $? -ne 0 ]; then
+    echo "Download failed! Exiting."
+    exit 1
+fi
+
+echo "Extracting File..."
+sudo mkdir -p "$GOROOT"
+sudo tar -C "$GOROOT" --strip-components=1 -xzf "$TEMP_DIRECTORY/go.tar.gz"
+touch "$HOME/.${shell_profile}"
+{
+    echo '# GoLang'
+    echo "export GOROOT=${GOROOT}"
+    echo 'export PATH=$GOROOT/bin:$PATH'
+    echo "export GOPATH=$GOPATH"
+    echo 'export PATH=$GOPATH/bin:$PATH'
+} >> "$HOME/.${shell_profile}"
+
+mkdir -p $GOPATH/{src,pkg,bin}
+source $HOME/.${shell_profile}
+rm -f "$TEMP_DIRECTORY/go.tar.gz"


### PR DESCRIPTION
This patch adds a new series of commands `devel` which allows
to interact with the go toolchain. For now, only the dependency
analyser has been added to the kraft tool.

The go runtime will be installed by a script if it is not
present on the host. In addition, the go toolchain will be
downloaded from a Github repo and then installed. Arguments
handling is then performed within the toolchain.

From now, the Github repository is hosted on my local account.
In the future, the toolchain can be directly integrated to the kraft 
repo.

Signed-off-by: Gaulthier Gain <gaulthier.gain@uliege.be>