### PR TITLE
Add Concourse CI/CD Pipelines

### DIFF
--- a/.concourse/scripts/generate-pipelines.sh
+++ b/.concourse/scripts/generate-pipelines.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Authors: Alexander Jung <alexander.jung@neclab.eu>
+#
+# Copyright (c) 2020, NEC Laboratories Europe GmbH.,
+#                     NEC Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Influential environmental variables
+WORKDIR=${WORKDIR:-$(pwd)/.concourse}
+TMPLDIR=${TMPLDIR:-$WORKDIR/templates}
+OUTDIR=${OUTDIR:-$WORKDIR/pipelines}
+BRANCH=${BRANCH:-staging}
+
+_help() {
+    cat <<EOF
+$0 - Generate kraft-centric pipelines for Concourse.
+
+The default operation with no arguments is to generate all possible
+pipelines available.
+
+Usage:
+  $0 [OPTIONS]
+
+Options:
+  -s --self     Generate reconfiguration pipeline only.
+  -h --help     Show this help menu and exit.
+     --pr       Only generate Pull Request pipelines.
+     --staging  Only generate staging pipelines.
+     --stable   Only generate stable pipelines.
+
+Influential environmental variables:
+  TMPLDIR       The directory where the templates reside
+                  (default $TMPLDIR).
+  OUTDIR        The output directory for the pipelines
+                  (default $OUTDIR).
+
+Help:
+  For help using this tool, please refer to the README.md at
+  https://github.com/unikraft/kraft.git
+EOF
+}
+
+TEMPLATE_NOTICE="# This file was auto-generated on `date`."
+
+GENERATE_PR=y
+GENERATE_STAGING=y
+GENERATE_STABLE=y
+GENERATE_SELF=y
+GENERATE_KRAFT=y
+SHOW_HELP=n
+
+# Parse arguments
+for i in "$@"; do
+  case $i in
+    --pr)
+      GENERATE_STAGING=n
+      GENERATE_STABLE=n
+      ;;
+    --staging)
+      GENERATE_PR=n
+      GENERATE_STABLE=n
+      ;;
+    --stable)
+      GENERATE_PR=n
+      GENERATE_STAGING=n
+      ;;
+    -s|--self)
+      GENERATE_KRAFT=n
+      ;;
+    -h|--help)
+      SHOW_HELP=y
+      ;;
+    *)
+      ;;
+  esac
+done
+
+if [[ $SHOW_HELP == 'y' ]]; then
+  _help
+  exit 0
+fi
+
+if [[ $GENERATE_PR == 'y' ]]; then
+  echo "Generating pull-request pipeline..."
+
+  KRAFTTEMPDIR_PR=$(mktemp -d)
+  cat $TMPLDIR/pr.yml > $KRAFTTEMPDIR_PR/template.yml
+  cat $TMPLDIR/data.yml > $KRAFTTEMPDIR_PR/data.yml
+  echo $TEMPLATE_NOTICE > $OUTDIR/kraft-pr.yml
+
+  echo " ... saving $OUTDIR/kraft-pr.yml"
+  ytt \
+    --data-value branch=$BRANCH \
+    --file $TMPLDIR/mixins.lib.yml \
+    --file $KRAFTTEMPDIR_PR \
+      >> $OUTDIR/kraft-pr.yml
+fi
+
+if [[ $GENERATE_STAGING == 'y' ]]; then
+  echo "Generating staging pipeline..."
+
+  KRAFTTEMPDIR_STAGING=$(mktemp -d)
+  cat $TMPLDIR/staging.yml > $KRAFTTEMPDIR_STAGING/template.yml
+  cat $TMPLDIR/data.yml > $KRAFTTEMPDIR_STAGING/data.yml
+  echo $TEMPLATE_NOTICE > $OUTDIR/kraft-staging.yml
+
+  echo " ... saving $OUTDIR/kraft-staging.yml"
+  ytt \
+    --data-value branch=$BRANCH \
+    --file $TMPLDIR/mixins.lib.yml \
+    --file $KRAFTTEMPDIR_STAGING \
+      >> $OUTDIR/kraft-staging.yml
+fi
+
+if [[ $GENERATE_STABLE == 'y' ]]; then
+  echo "Generating stable pipeline..."
+
+  KRAFTTEMPDIR_STABLE=$(mktemp -d)
+  cat $TMPLDIR/stable.yml > $KRAFTTEMPDIR_STABLE/template.yml
+  cat $TMPLDIR/data.yml > $KRAFTTEMPDIR_STABLE/data.yml
+  echo $TEMPLATE_NOTICE > $OUTDIR/kraft-stable.yml
+
+  echo " ... saving $OUTDIR/kraft-stable.yml"
+  ytt \
+    --data-value branch=$BRANCH \
+    --file $TMPLDIR/mixins.lib.yml \
+    --file $KRAFTTEMPDIR_STABLE \
+      >> $OUTDIR/kraft-stable.yml
+fi
+
+# if [[ $GENERATE_SELF == '' ]]; then
+
+# fi

--- a/.concourse/tasks/build-docker-gcc.yml
+++ b/.concourse/tasks/build-docker-gcc.yml
@@ -1,0 +1,30 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: vito/oci-build-task
+
+params:
+  DOCKERFILE: package/docker/Dockerfile.gcc
+  CONTEXT: .
+  BUILD_ARG_HTTP_PROXY: ((http_proxy))
+  BUILD_ARG_HTTPS_PROXY: ((https_proxy))
+  # BUILD_ARG_UK_ARCH: x86_64
+  # BUILD_ARG_GCC_VERSION: 9.2.0
+  # BUILD_ARG_BINUTILS_VERSION: 2.31.1
+  # BUILD_ARG_GLIB_VERSION: 2.11
+
+inputs:
+  - name: kraft
+    path: .
+
+outputs:
+  - name: image
+
+caches:
+  - path: cache
+
+run:
+  path: build

--- a/.concourse/tasks/build-docker-kraft.yml
+++ b/.concourse/tasks/build-docker-kraft.yml
@@ -1,0 +1,31 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: vito/oci-build-task
+
+inputs:
+  - name: kraft
+    path: .
+
+params:
+  DOCKERFILE: package/docker/Dockerfile.kraft
+  CONTEXT: .
+  BUILD_ARG_HTTP_PROXY: ((http_proxy))
+  BUILD_ARG_HTTPS_PROXY: ((https_proxy))
+  # BUILD_ARG_GCC_VERSION: ((kraft_gcc_version))
+  # BUILD_ARG_UK_ARCH: ((kraft_uk_arch))
+  # BUILD_ARG_GCC_PREFIX: ((kraft_gcc_prefix))
+  # BUILD_ARG_YTT_VERSION: ((kraft_ytt_version))
+  # BUILD_ARG_YQ_VERSION: ((kraft_yq_version))
+
+outputs:
+  - name: image
+
+caches:
+  - path: cache
+
+run:
+  path: build

--- a/.concourse/tasks/build-docker-pkg-deb.yml
+++ b/.concourse/tasks/build-docker-pkg-deb.yml
@@ -1,0 +1,28 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: vito/oci-build-task
+
+params:
+  DOCKERFILE: package/docker/Dockerfile.pkg-deb
+  CONTEXT: .
+  BUILD_ARG_HTTP_PROXY: ((http_proxy))
+  BUILD_ARG_HTTPS_PROXY: ((https_proxy))
+  # BUILD_ARG_PKG_VENDOR: debian
+  # BUILD_ARG_PKG_DISTRIBUTION: stretch
+
+inputs:
+  - name: kraft
+    path: .
+
+outputs:
+  - name: image
+
+caches:
+  - path: cache
+
+run:
+  path: build

--- a/.concourse/tasks/build-docker-qemu.yml
+++ b/.concourse/tasks/build-docker-qemu.yml
@@ -1,0 +1,27 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: vito/oci-build-task
+
+params:
+  DOCKERFILE: package/docker/Dockerfile.qemu
+  CONTEXT: .
+  BUILD_ARG_HTTP_PROXY: ((http_proxy))
+  BUILD_ARG_HTTPS_PROXY: ((https_proxy))
+  # BUILD_ARG_QEMU_VERSION: ((kraft_qemu_version))
+
+inputs:
+  - name: kraft
+    path: .
+
+outputs:
+  - name: image
+
+caches:
+  - path: cache
+
+run:
+  path: build

--- a/.concourse/tasks/build-pkg-deb.yml
+++ b/.concourse/tasks/build-pkg-deb.yml
@@ -24,7 +24,7 @@ run:
       DIRTY= \
       DOCKER= \
       make get-version > dist/version
-      
+
       PKG_VENDOR=((vendor)) \
       PKG_DISTRIBUTION=((distribution)) \
       APP_VERSION=$(cat dist/version) \

--- a/.concourse/tasks/build-pkg-deb.yml
+++ b/.concourse/tasks/build-pkg-deb.yml
@@ -7,6 +7,9 @@ image_resource:
     repository: unikraft/pkg-deb
     tag: ((tag))
 
+params:
+  DIRTY:
+
 inputs:
   - name: kraft
     path: .
@@ -21,7 +24,7 @@ run:
     - |
       PKG_VENDOR=((vendor)) \
       PKG_DISTRIBUTION=((distribution)) \
-      DIRTY= \
+      DIRTY=$DIRTY \
       DOCKER= \
       make get-version > dist/version
 

--- a/.concourse/tasks/build-pkg-deb.yml
+++ b/.concourse/tasks/build-pkg-deb.yml
@@ -1,0 +1,32 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: unikraft/pkg-deb
+    tag: ((tag))
+
+inputs:
+  - name: kraft
+    path: .
+
+outputs:
+  - name: dist
+
+run:
+  path: bash
+  args:
+    - -cex
+    - |
+      PKG_VENDOR=((vendor)) \
+      PKG_DISTRIBUTION=((distribution)) \
+      DIRTY= \
+      DOCKER= \
+      make get-version > dist/version
+      
+      PKG_VENDOR=((vendor)) \
+      PKG_DISTRIBUTION=((distribution)) \
+      APP_VERSION=$(cat dist/version) \
+      DOCKER= \
+      make pkg-deb

--- a/.concourse/tasks/build-pkg-pypi.yaml
+++ b/.concourse/tasks/build-pkg-pypi.yaml
@@ -1,0 +1,31 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: unikraft/kraft
+    tag: ((tag))
+
+params:
+  DIRTY:
+
+inputs:
+  - name: kraft
+    path: .
+
+outputs:
+  - name: dist
+
+run:
+  path: bash
+  args:
+    - -cex
+    - |
+      DIRTY=$DIRTY \
+      DOCKER= \
+      make get-version > dist/version
+
+      APP_VERSION=$(cat dist/version) \
+      DOCKER= \
+      make sdist

--- a/.concourse/tasks/test-kraft.yml
+++ b/.concourse/tasks/test-kraft.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: unikraft/kraft
+    tag: latest-dev
+
+inputs:
+  - name: kraft
+    path: .
+
+params:
+  HTTP_PROXY: ((http_proxy))
+  HTTPS_PROXY: ((https_proxy))
+
+run:
+  path: bash
+  args:
+    - -cex
+    - ((target_cmd))

--- a/.concourse/tasks/test-pkg-deb.yml
+++ b/.concourse/tasks/test-pkg-deb.yml
@@ -1,0 +1,24 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: ((vendor))
+    tag: ((distribution))
+
+run:
+  path: bash
+  args:
+    - -cex
+    - |
+      export LANG=C.UTF-8;
+      export LC_ALL=C.UTF-8;
+      export DEBIAN_FRONTEND=noninteractive;
+      apt-get update;
+      apt-get install -y wget;
+      wget -O unikraft-tools.deb http://releases.unikraft.org/linux/((vendor))/pool/((branch))/u/unikraft-tools/((basename))
+      dpkg -i ./unikraft-tools.deb || true
+      apt-get install -y -f
+      basename="((basename))"
+      kraft --version

--- a/.concourse/templates/mixins.lib.yml
+++ b/.concourse/templates/mixins.lib.yml
@@ -1,0 +1,198 @@
+#! SPDX-License-Identifier: BSD-3-Clause
+#!
+#! Authors: Alexander Jung <alexander.jung@neclab.eu>
+#!
+#! Copyright (c) 2020, NEC Laboratories Europe GmbH.,
+#!                     NEC Corporation. All rights reserved.
+#!
+#! Redistribution and use in source and binary forms, with or without
+#! modification, are permitted provided that the following conditions
+#! are met:
+#!
+#! 1. Redistributions of source code must retain the above copyright
+#!    notice, this list of conditions and the following disclaimer.
+#! 2. Redistributions in binary form must reproduce the above copyright
+#!    notice, this list of conditions and the following disclaimer in the
+#!    documentation and/or other materials provided with the distribution.
+#! 3. Neither the name of the copyright holder nor the names of its
+#!    contributors may be used to endorse or promote products derived from
+#!    this software without specific prior written permission.
+#!
+#! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#! POSSIBILITY OF SUCH DAMAGE.
+
+#! Concourse task to notify Mattermost of task failure
+#!
+#! params
+#!   task: the name of the task which failed
+#!   base_ref: the name of the branch which it failed on
+#!   base_sha: the commit sha which the task failed on
+#!   error_log: the log of the error to be printed
+#!
+#@ def mattermost_notify_failure(repo, task, base_ref, base_sha, error_log=""):
+put: mattermost-notify
+params:
+  silent: true #! prevent logging to hide Mattermost API communication
+  channel: "#cicd-dev"
+  #@yaml/text-templated-strings
+  text: |
+    :exclamation: **Pipeline [`$BUILD_PIPELINE_NAME`]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME)@[`(@= str(base_ref) @)`](https://github.com/unikraft/(@= str(repo) @)/tree/(@= str(base_sha) @)) / [`$BUILD_JOB_NAME`]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME) on task [`(@= str(task) @)`]($ATC_EXTERNAL_URL/builds/$BUILD_ID) failed!**
+    (@- if error_log != "": @)
+    ```bash
+    (@= error_log @)
+    ```
+    (@- end @)
+    [View in Concourse]($ATC_EXTERNAL_URL/builds/$BUILD_ID) | `fly i -b $BUILD_ID -s (@= str(task) @)`
+#@ end
+
+#! Set a pull-request status
+#!
+#! params:
+#!   status: The status, options: pending, success, failure
+#!   context: The name of the task in context
+#!   description: Short description of task
+#!
+#@ def pull_request_status(status="success", context="", description=""):
+put: pull-request-status-update
+resource: pull-request
+get_params:
+  skip_download: true
+inputs:
+  - pull-request
+params:
+  context: #@ context
+  description: #@ description
+  path: pull-request
+  status: #@ status
+#@ end
+
+#! Resource for matching Reviewed-By trailers.  This is used for approving and
+#! starting the merge window of the PR.
+#!
+#! params:
+#!   repo: The remote repository where the PR originates
+#!
+#@ def pr_approved_resource(repo):
+name: pull-request-approved
+type: github-pr-comment-resource
+icon: check-circle
+source:
+  repository: #@ repo
+  access_token: ((github.access-token))
+  comments: ["^\\/reviewed-by (?P<reviewed_by>.*)$"]
+  map_comment_meta: true
+#@ end
+
+#! Checkpatch job plan
+#!
+#! params:
+#!   unikraft: The unikraft resource object
+#!
+#@ def checkpatch_pr_job(unikraft):
+name: checkpatch
+serial: true
+plan:
+  - get: pull-request
+    trigger: true
+    version: every
+  - in_parallel:
+      steps:
+        - load_var: pull-request-id
+          file: pull-request/.git/resource/pr
+        - load_var: pull-request-sha
+          file: pull-request/.git/resource/head_sha
+        - get: pipelines-and-tasks
+        - get: #@ unikraft.resource
+  
+  - put: pull-request-status-update
+    resource: pull-request
+    get_params:
+      list_changed_files: true
+      skip_download: true
+    inputs:
+      - pull-request
+    params:
+      context: checkpatch
+      description: Running checkpatch
+      path: pull-request
+      status: pending
+
+  - task: checkpatch
+    file: pipelines-and-tasks/tasks/checkpatch.yml
+    input_mapping:
+      source: pull-request
+      unikraft: #@ unikraft.resource
+
+    on_failure:
+      do:
+        - load_var: comment
+          file: comment/comment.txt
+          format: raw
+        - put: pull-request-status-update
+          resource: pull-request
+          get_params:
+            skip_download: true
+          inputs:
+            - pull-request
+          params:
+            context: checkpatch
+            description: Failed against checkpatch
+            path: pull-request
+            status: failure
+            comment: ((.:comment))
+            delete_previous_comments: true
+
+    on_success:
+      put: pull-request-status-update
+      resource: pull-request
+      get_params:
+        skip_download: true
+      inputs:
+        - pull-request
+      params:
+        context: checkpatch
+        description: Passed against checkpatch
+        path: pull-request
+        status: success
+#@ end
+
+#! Concourse resource for release artifacts
+#!
+#! params:
+#!   vendor: The vendor name for the deb resource
+#!   distribution: The distribution name for the deb resource
+#!   extra: Additional text to append to the resource name
+#!
+#@ def deb_resource(vendor, distribution, extra=""):
+name: #@ "{}-{}-deb{}".format(vendor, distribution, extra)
+type: rclone
+icon: archive-arrow-up-outline
+source:
+  config: |
+    [remote]
+    type = sftp
+    host = ((releases.host))
+    user = ((releases.user))
+    port = ((releases.port))
+    key_file = /tmp/rclone/key_file
+  files:
+    key_file: |
+      ((releases.private-key))
+#@ end
+
+#@ def publish_deb(vendor, distribution):
+put: #@ "{}-{}-deb".format(vendor, distribution)
+params:
+  source: dist/*.deb
+  destination:
+    - dir: #@ "remote:((releases.root-dir))/cicd-input/{}/{}/".format(vendor, distribution)
+#@ end

--- a/.concourse/templates/pr.yml
+++ b/.concourse/templates/pr.yml
@@ -1,0 +1,480 @@
+#! SPDX-License-Identifier: BSD-3-Clause
+#!
+#! Authors: Alexander Jung <a.jung@lancs.ac.uk>
+#!
+#! Copyright (c) 2020, Lancaster University.  All rights reserved.
+#!
+#! Redistribution and use in source and binary forms, with or without
+#! modification, are permitted provided that the following conditions
+#! are met:
+#!
+#! 1. Redistributions of source code must retain the above copyright
+#!    notice, this list of conditions and the following disclaimer.
+#! 2. Redistributions in binary form must reproduce the above copyright
+#!    notice, this list of conditions and the following disclaimer in the
+#!    documentation and/or other materials provided with the distribution.
+#! 3. Neither the name of the copyright holder nor the names of its
+#!    contributors may be used to endorse or promote products derived from
+#!    this software without specific prior written permission.
+#!
+#! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#! POSSIBILITY OF SUCH DAMAGE.
+
+#@ load("@ytt:data",     "data")
+#@ load("@ytt:assert",   "assert")
+#@ load("@ytt:struct",   "struct")
+#@ load("mixins.lib.yml", \
+#@  "pull_request_status", \
+#@  "deb_resource" \
+#@ )
+
+#! Template immediate data values
+#@ branch   = data.values.branch or \
+#@            assert.fail("branch must be specified")
+#@ versions = data.values.versions or \
+#@            assert.fail("versions must be specified")
+#@ debs     = data.values.debs or \
+#@            assert.fail("debs must be specified")
+#@ tests    = data.values.tests or \
+#@            assert.fail("tests must be specified")
+#@ archs    = data.values.archs or \
+#@            assert.fail("archs must be specified")
+
+
+---
+groups:
+  - name: all
+    jobs:
+      - docker-qemu
+      - docker-kraft
+      #@ for arch in archs:
+      - #@ "docker-gcc-{}".format(arch.name)
+      #@ end
+      #@ for test in tests:
+      - #@ test.name
+      #@ end
+      #@ for vendor in debs:
+      #@ for distribution in vendor.distributions:
+      - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+      - #@ "pkg-{}-{}".format(vendor.name, distribution)
+      - #@ "test-pkg-{}-{}".format(vendor.name, distribution)
+      #@ end
+      #@ end
+  
+  - name: tests
+    jobs:
+      #@ for test in tests:
+      - #@ test.name
+      #@ end
+      #@ for vendor in debs:
+      #@ for distribution in vendor.distributions:
+      - #@ "test-pkg-{}-{}".format(vendor.name, distribution)
+      #@ end
+      #@ end
+
+  - name: docker
+    jobs:
+      - docker-qemu
+      - docker-kraft
+      #@ for arch in archs:
+      - #@ "docker-gcc-{}".format(arch.name)
+      #@ end
+      #@ for vendor in debs:
+      #@ for distribution in vendor.distributions:
+      - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+      #@ end
+      #@ end
+  
+  #@ for vendor in debs:
+  - name: #@ "pkg-{}".format(vendor.name)
+    jobs:
+      #@ for distribution in vendor.distributions:
+      - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+      - #@ "pkg-{}-{}".format(vendor.name, distribution)
+      - #@ "test-pkg-{}-{}".format(vendor.name, distribution)
+      #@ end
+  #@ end
+
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+
+  - name: docker-image-resource
+    type: docker-image
+    privileged: true
+    source:
+      repository: unikraft/concourse-docker-image-resource
+      tag: latest
+
+  - name: rclone
+    type: docker-image
+    source:
+      repository: ndrjng/concourse-rclone-resource
+      tag: latest
+
+
+resources:
+  - name: pull-request
+    type: pull-request
+    icon: github
+    check_every: 30m
+    webhook_token: ((webhook-token))
+    source:
+      repository: unikraft/kraft
+      access_token: ((github.access-token))
+      base_branch: #@ branch
+      ignore_drafts: false
+
+  - name: docker-qemu
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/qemu
+
+  #@ for arch in archs:
+  - name: #@ "docker-gcc-{}".format(arch.name)
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/gcc
+  #@ end
+
+  - name: docker-kraft
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/kraft
+
+  - name: docker-kraft-dev
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/kraft
+
+  #@ for vendor in debs:
+  #@ for distribution in vendor.distributions:
+  - #@ deb_resource(vendor.name, distribution)
+  - name: #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+    icon: docker
+    type: docker-image-resource
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/pkg-deb
+  #@ end
+  #@ end
+
+
+jobs:
+  - name: docker-qemu
+    plan:
+      - get: pull-request
+        trigger: true
+        version: every
+
+      - #@ pull_request_status("pending", "docker-qemu", "Building image...")
+
+      - task: docker-qemu
+        privileged: true
+        file: pull-request/.concourse/tasks/build-docker-qemu.yml
+        input_mapping:
+          kraft: pull-request
+        params:
+          BUILD_ARG_QEMU_VERSION: #@ versions.qemu
+        on_success: #@ pull_request_status("success", "docker-qemu", "Successfully built unikraft/qemu image")
+        on_failure: #@ pull_request_status("failure", "docker-qemu", "Failed to build unikraft/qemu image")
+
+      - load_var: docker-qemu-digest
+        file: image/digest
+
+      - put: docker-qemu
+        params:
+          load_file: image/image.tar
+          load_repository: ((.:docker-qemu-digest))
+          tag_file: pull-request/.git/resource/pr
+          tag_prefix: pr-
+        get_params:
+          skip_download: true
+  
+  #@ for arch in archs:
+  - name: #@ "docker-gcc-{}".format(arch.name)
+    plan:
+      - get: pull-request
+        trigger: true
+        version: every
+
+      - #@ pull_request_status("pending", "docker-gcc-{}".format(arch.name), "Building image...")
+
+      - file: pull-request/.git/resource/pr
+        load_var: pull-request-number
+
+      - task: docker-gcc
+        privileged: true
+        file: pull-request/.concourse/tasks/build-docker-gcc.yml
+        input_mapping:
+          kraft: pull-request
+        params:
+          UK_ARCH: #@ arch.name
+        on_success: #@ pull_request_status("success", "docker-gcc-{}".format(arch.name), "Successfully built unikraft/gcc:pr-((.:pull-request-number))-{}".format(arch.name))
+        on_failure: #@ pull_request_status("failure", "docker-gcc-{}".format(arch.name), "Failed to build unikraft/gcc:pr-((.:pull-request-number))-{}".format(arch.name))
+
+      - load_var: docker-gcc-digest
+        file: image/digest
+
+      - put: #@ "docker-gcc-{}".format(arch.name)
+        params:
+          load_file: image/image.tar
+          load_repository: ((.:docker-gcc-digest))
+          tag: #@ "pr-((.:pull-request-number))-{}".format(arch.name)
+        get_params:
+          skip_download: true
+  #@ end
+
+  - name: docker-kraft
+    plan:
+      - get: pull-request
+        trigger: true
+        version: every
+        passed:
+          - docker-qemu
+        #@ for arch in archs:
+          - #@ "docker-gcc-{}".format(arch.name)
+        #@ end
+
+      - get: docker-qemu
+        passed:
+          - docker-qemu
+
+      #@ for arch in archs:
+      - get: #@ "docker-gcc-{}".format(arch.name)
+        passed:
+          - #@ "docker-gcc-{}".format(arch.name)
+      #@ end
+
+      - file: pull-request/.git/resource/pr
+        load_var: pull-request-number
+
+      - in_parallel:
+          fail_fast: true
+          steps:
+            
+            #! build the base iamge
+            - do:
+              - #@ pull_request_status("pending", "docker-kraft", "Building image...")
+
+              - task: docker-kraft
+                privileged: true
+                file: pull-request/.concourse/tasks/build-docker-kraft.yml
+                input_mapping:
+                  kraft: pull-request
+                params:
+                  BUILD_ARG_GCC_VERSION: pr-((.:pull-request-number))
+                  BUILD_ARG_QEMU_VERSION: pr-((.:pull-request-number))
+                on_success: #@ pull_request_status("success", "docker-kraft", "Successfully built unikraft/kraft:pr-((.:pull-request-number))")
+                on_failure: #@ pull_request_status("failure", "docker-kraft", "Failed to build unikraft/kraft:pr-((.:pull-request-number))")
+
+              - load_var: docker-kraft-digest
+                file: image/digest
+
+              - put: docker-kraft
+                params:
+                  load_file: image/image.tar
+                  load_repository: ((.:docker-kraft-digest))
+                  tag_file: pull-request/.git/resource/pr
+                  tag_prefix: pr-
+                get_params:
+                  skip_download: true
+            
+            #! build the developer image
+            - do:
+              - #@ pull_request_status("pending", "docker-kraft-dev", "Building image...")
+
+              - task: docker-kraft-dev
+                privileged: true
+                file: pull-request/.concourse/tasks/build-docker-kraft.yml
+                input_mapping:
+                  kraft: pull-request
+                params:
+                  TARGET: kraft-dev
+                on_success: #@ pull_request_status("success", "docker-kraft-dev", "Successfully built unikraft/kraft:dev-pr-((.:pull-request-number))")
+                on_failure: #@ pull_request_status("failure", "docker-kraft-dev", "Failed to build unikraft/kraft:dev-pr-((.:pull-request-number))")
+
+              - load_var: docker-kraft-dev-digest
+                file: image/digest
+
+              - put: docker-kraft-dev
+                params:
+                  load_file: image/image.tar
+                  load_repository: ((.:docker-kraft-dev-digest))
+                  tag_file: pull-request/.git/resource/pr
+                  tag_prefix: dev-pr-
+                get_params:
+                  skip_download: true
+
+  #@ for test in tests:
+  - name: #@ test.name
+    plan:
+    - get: pull-request
+      trigger: true
+      version: latest
+      passed:
+        - docker-kraft
+      params:
+        fetch_tags: true
+
+    - #@ pull_request_status("pending", test.name, "Testing...")
+  
+    - get: docker-kraft-dev
+      passed:
+        - docker-kraft
+
+    - task: #@ test.name
+      file: pull-request/.concourse/tasks/test-kraft.yml
+      image: docker-kraft-dev
+      vars:
+        target_cmd: #@ test.cmd
+      input_mapping:
+        kraft: pull-request
+      on_success: #@ pull_request_status("success", test.name, "Test passed")
+      on_failure: #@ pull_request_status("failure", test.name, "Test failed")
+  #@ end
+
+  #@ for vendor in debs:
+  #@ for distribution in vendor.distributions:
+  - name: #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+    plan:
+      - get: pull-request
+        trigger: true
+        version: every
+        passed:
+        #@ for test in tests:
+          - #@ test.name
+        #@ end
+
+      - #@ pull_request_status("pending", "docker-pkg-{}-{}".format(vendor.name, distribution), "Building image...")
+
+      - file: pull-request/.git/resource/pr
+        load_var: pull-request-number
+
+      - task: docker-pkg-deb
+        privileged: true
+        file: pull-request/.concourse/tasks/build-docker-pkg-deb.yml
+        input_mapping:
+          kraft: pull-request
+        params:
+          BUILD_ARG_PKG_VENDOR: #@ vendor.name
+          BUILD_ARG_PKG_DISTRIBUTION: #@ distribution
+        on_success: #@ pull_request_status("success", "docker-pkg-{}-{}".format(vendor.name, distribution), "Successfully built unikraft/pkg-deb:{}-{}-pr-((.:pull-request-number)) image".format(vendor.name, distribution))
+        on_failure: #@ pull_request_status("failure", "docker-pkg-{}-{}".format(vendor.name, distribution), "Failed to build unikraft/pkg-deb:{}-{}-pr-((.:pull-request-number)) image".format(vendor.name, distribution))
+
+      - load_var: docker-pkg-deb-digest
+        file: image/digest
+
+      - put: #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+        params:
+          load_file: image/image.tar
+          load_repository: ((.:docker-pkg-deb-digest))
+          tag_file: pull-request/.git/resource/pr
+          tag_prefix: #@ "{}-{}-pr-".format(vendor.name, distribution)
+        get_params:
+          skip_download: true
+  
+  - name: #@ "pkg-{}-{}".format(vendor.name, distribution)
+    plan:
+      - get: pull-request
+        trigger: true
+        version: every
+        passed:
+          - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+        params:
+          fetch_tags: true
+
+      - #@ pull_request_status("pending", "pkg-{}-{}".format(vendor.name, distribution), "Packaging .deb...")
+      
+      - get: #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+        passed:
+          - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+
+      - file: pull-request/.git/resource/pr
+        load_var: pull-request-number
+
+      - task: pkg-deb
+        file: pull-request/.concourse/tasks/build-pkg-deb.yml
+        image: #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+        vars:
+          tag: pr-((.:pull-request-number))
+          vendor: #@ vendor.name
+          distribution: #@ distribution
+        params:
+          DIRTY: -pr-((.:pull-request-number))
+        input_mapping:
+          kraft: pull-request
+        on_success: #@ pull_request_status("success", "pkg-{}-{}".format(vendor.name, distribution), "Packaging .deb passed")
+        on_failure: #@ pull_request_status("failure", "pkg-{}-{}".format(vendor.name, distribution), "Packaging .deb failed")
+
+      - load_var: kraft-version
+        file: dist/version
+
+      - put: #@ "{}-{}-deb".format(vendor.name, distribution)
+        params:
+          source: dist/*.deb
+          destination:
+            - dir: #@ "remote:((releases.deb-dir))"
+              path: #@ "/{}/{}/{}/".format(vendor.name, distribution, "testing")
+              vendor: #@ vendor.name
+              distribution: #@ distribution
+              branch: testing
+  
+  - name: #@ "test-pkg-{}-{}".format(vendor.name, distribution)
+    plan:
+      - get: pull-request
+        trigger: true
+        version: latest
+        passed:
+          - #@ "pkg-{}-{}".format(vendor.name, distribution)
+
+      - #@ pull_request_status("pending", "test-pkg-{}-{}".format(vendor.name, distribution), "Testing .deb install...")
+      
+      - get: #@ "{}-{}-deb".format(vendor.name, distribution)
+        passed:
+          - #@ "pkg-{}-{}".format(vendor.name, distribution)
+      
+      - load_var: basename
+        file: #@ "{}-{}-deb/basename".format(vendor.name, distribution)
+
+      - file: pull-request/.git/resource/pr
+        load_var: pull-request-number
+
+      - task: test-pkg-deb
+        file: pull-request/.concourse/tasks/test-pkg-deb.yml
+        vars:
+          tag: pr-((.:pull-request-number))
+          vendor: #@ vendor.name
+          distribution: #@ distribution
+          branch: testing
+          basename: ((.:basename))
+        input_mapping:
+          kraft: pull-request
+        on_success: #@ pull_request_status("success", "test-pkg-{}-{}".format(vendor.name, distribution), "Installing .deb passed")
+        on_failure: #@ pull_request_status("failure", "test-pkg-{}-{}".format(vendor.name, distribution), "Installing .deb failed")
+  #@ end
+  #@ end

--- a/.concourse/templates/stable.yml
+++ b/.concourse/templates/stable.yml
@@ -1,0 +1,509 @@
+#! SPDX-License-Identifier: BSD-3-Clause
+#!
+#! Authors: Alexander Jung <a.jung@lancs.ac.uk>
+#!
+#! Copyright (c) 2020, Lancaster University.  All rights reserved.
+#!
+#! Redistribution and use in source and binary forms, with or without
+#! modification, are permitted provided that the following conditions
+#! are met:
+#!
+#! 1. Redistributions of source code must retain the above copyright
+#!    notice, this list of conditions and the following disclaimer.
+#! 2. Redistributions in binary form must reproduce the above copyright
+#!    notice, this list of conditions and the following disclaimer in the
+#!    documentation and/or other materials provided with the distribution.
+#! 3. Neither the name of the copyright holder nor the names of its
+#!    contributors may be used to endorse or promote products derived from
+#!    this software without specific prior written permission.
+#!
+#! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#! POSSIBILITY OF SUCH DAMAGE.
+
+#@ load("@ytt:data",     "data")
+#@ load("@ytt:assert",   "assert")
+#@ load("@ytt:struct",   "struct")
+#! #@ load("unikraft.star", "uk")
+#@ load("mixins.lib.yml", "deb_resource")
+
+#! Template immediate data values
+#@ branch   = data.values.branch or \
+#@            assert.fail("branch must be specified")
+#@ versions = data.values.versions or \
+#@            assert.fail("versions must be specified")
+#@ debs     = data.values.debs or \
+#@            assert.fail("debs must be specified")
+#@ tests    = data.values.tests or \
+#@            assert.fail("tests must be specified")
+#@ archs    = data.values.archs or \
+#@            assert.fail("archs must be specified")
+
+---
+groups:
+  - name: all
+    jobs:
+      - "*"
+  
+  - name: tests
+    jobs:
+      - test-*
+
+  - name: docker
+    jobs:
+      - docker-*
+  
+  #@ for vendor in debs:
+  - name: #@ "pkg-{}".format(vendor.name)
+    jobs:
+      #@ for distribution in vendor.distributions:
+      - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+      - #@ "pkg-{}-{}".format(vendor.name, distribution)
+      - #@ "test-pkg-{}-{}".format(vendor.name, distribution)
+      #@ end
+  #@ end
+
+
+resource_types:
+  - name: docker-image-resource
+    type: docker-image
+    privileged: true
+    source:
+      repository: unikraft/concourse-docker-image-resource
+      tag: latest
+
+  - name: rclone
+    type: docker-image
+    source:
+      repository: ndrjng/concourse-rclone-resource
+      tag: latest
+
+
+resources:
+  - name: #@ "kraft-{}".format(branch)
+    type: git
+    icon: github
+    check_every: 30m
+    webhook_token: ((webhook-token))
+    source:
+      uri: https://github.com/unikraft/kraft.git
+      branch: concourse
+      fetch_tags: true
+
+  - name: docker-qemu
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/qemu
+      tag: #@ "{}-{}".format(versions.qemu, branch)
+
+  - name: docker-qemu-smoke
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/qemu
+      tag: #@ "{}-{}-smoke".format(versions.qemu, branch)
+
+  #@ for arch in archs:
+  - name: #@ "docker-gcc-{}".format(arch.name)
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/gcc
+      tag: #@ "{}-{}-{}".format(versions.gcc, arch.name, branch)
+
+  - name: #@ "docker-gcc-{}-smoke".format(arch.name)
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/gcc
+      tag: #@ "{}-{}-{}-smoke".format(versions.gcc, arch.name, branch)
+  #@ end
+
+  - name: docker-kraft
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/kraft
+      tag: #@ branch
+
+  - name: docker-kraft-smoke
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/kraft
+      tag: #@ "{}-smoke".format(branch)
+
+  - name: docker-kraft-dev
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/kraft
+      tag: #@ "{}-dev".format(branch)
+
+  - name: docker-kraft-dev-smoke
+    type: docker-image-resource
+    icon: docker
+    source: 
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/kraft
+      tag: #@ "{}-dev-smoke".format(branch)
+
+  #@ for vendor in debs:
+  #@ for distribution in vendor.distributions:
+  - #@ deb_resource(vendor.name, distribution)
+  - #@ deb_resource(vendor.name, distribution, "-smoke")
+  - name: #@ "docker-pkg-{}-{}-{}".format(vendor.name, distribution, branch)
+    icon: docker
+    type: docker-image-resource
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/pkg-deb
+      tag: #@ "{}-{}-{}".format(vendor.name, distribution, branch)
+  #@ end
+  #@ end
+
+jobs:
+  - name: docker-qemu
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+
+      - task: docker-qemu
+        privileged: true
+        file: #@ "kraft-{}/.concourse/tasks/build-docker-qemu.yml".format(branch)
+        input_mapping:
+          kraft: #@ "kraft-{}".format(branch)
+        params:
+          BUILD_ARG_QEMU_VERSION: #@ versions.qemu
+
+      - load_var: docker-qemu-digest
+        file: image/digest
+
+      - put: docker-qemu-smoke
+        params:
+          load_file: image/image.tar
+          load_repository: ((.:docker-qemu-digest))
+        get_params:
+          skip_download: true
+
+  #@ for arch in archs:
+  - name: #@ "docker-gcc-{}".format(arch.name)
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+
+      - task: docker-gcc
+        privileged: true
+        file: #@ "kraft-{}/.concourse/tasks/build-docker-gcc.yml".format(branch)
+        input_mapping:
+          kraft: #@ "kraft-{}".format(branch)
+        params:
+          BUILD_ARG_UK_ARCH: #@ arch.name
+          BUILD_ARG_GCC_VERSION: #@ versions.gcc
+          BUILD_ARG_BINUTILS_VERSION: #@ versions.binutils
+          BUILD_ARG_GLIB_VERSION: #@ versions.glib
+
+      - load_var: docker-gcc-digest
+        file: image/digest
+
+      - put: #@ "docker-gcc-{}-smoke".format(arch.name)
+        params:
+          load_file: image/image.tar
+          load_repository: ((.:docker-gcc-digest))
+        get_params:
+          skip_download: true
+  #@ end
+
+  - name: docker-kraft
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+        passed:
+          - docker-qemu
+      #@ for arch in archs:
+          - #@ "docker-gcc-{}".format(arch.name)
+      #@ end
+      
+      - get: docker-qemu-smoke
+        passed:
+          - docker-qemu
+
+      #@ for arch in archs:
+      - get: #@ "docker-gcc-{}-smoke".format(arch.name)
+        passed:
+          - #@ "docker-gcc-{}".format(arch.name)
+      #@ end
+
+      - in_parallel:
+          fail_fast: true
+          steps:
+            
+            #! build the base iamge
+            - do:
+              - task: docker-kraft
+                privileged: true
+                file: #@ "kraft-{}/.concourse/tasks/build-docker-kraft.yml".format(branch)
+                input_mapping:
+                  kraft: #@ "kraft-{}".format(branch)
+                params:
+                  TARGET: kraft
+                  BUILD_ARG_GCC_VERSION: #@ versions.gcc
+
+              - load_var: docker-kraft-digest
+                file: image/digest
+
+              - put: docker-kraft-smoke
+                params:
+                  load_file: image/image.tar
+                  load_repository: ((.:docker-kraft-digest))
+                get_params:
+                  skip_download: true
+
+            #! build the developer image
+            - do:
+              - task: docker-kraft-dev
+                privileged: true
+                file: #@ "kraft-{}/.concourse/tasks/build-docker-kraft.yml".format(branch)
+                input_mapping:
+                  kraft: #@ "kraft-{}".format(branch)
+                params:
+                  TARGET: kraft-dev
+                  BUILD_ARG_GCC_VERSION: #@ versions.gcc
+
+              - load_var: docker-kraft-dev-digest
+                file: image/digest
+
+              - put: docker-kraft-dev-smoke
+                params:
+                  load_file: image/image.tar
+                  load_repository: ((.:docker-kraft-dev-digest))
+                get_params:
+                  skip_download: true
+
+  #@ for test in tests:
+  - name: #@ test.name
+    plan:
+    - get: #@ "kraft-{}".format(branch)
+      trigger: true
+      version: latest
+      passed:
+        - docker-kraft
+        
+    - get: docker-kraft-dev-smoke
+      passed:
+        - docker-kraft
+
+    - task: #@ test.name
+      file: #@ "kraft-{}/.concourse/tasks/test-kraft.yml".format(branch)
+      image: docker-kraft-dev-smoke
+      vars:
+        target_cmd: #@ test.cmd
+      input_mapping:
+        kraft: #@ "kraft-{}".format(branch)
+  #@ end
+
+  - name: release-docker
+    plan:
+      - in_parallel:
+          fail_fast: true
+          steps:
+            - do:
+              - get: docker-kraft-dev-smoke
+                trigger: true
+                version: latest
+                passed:
+                  - docker-kraft
+                #@ for test in tests:
+                  - #@ test.name
+                #@ end
+                params:
+                  save: true
+              - load_var: docker-kraft-dev-digest
+                file: docker-kraft-dev-smoke/image-id
+              - put: docker-kraft-dev
+                params:
+                  load_file: docker-kraft-dev-smoke/image
+                  load_repository: ((.:docker-kraft-dev-digest))
+                get_params:
+                  skip_download: true
+
+            - do:
+              - get: docker-kraft-smoke
+                passed:
+                  - docker-kraft
+                params:
+                  save: true
+              - load_var: docker-kraft-digest
+                file: docker-kraft-smoke/image-id
+              - put: docker-kraft
+                params:
+                  load_file: docker-kraft-smoke/image
+                  load_repository: ((.:docker-kraft-digest))
+                get_params:
+                  skip_download: true
+            
+            - do:
+              - get: docker-qemu-smoke
+                passed:
+                  - docker-qemu
+                params:
+                  save: true
+              - load_var: docker-qemu-digest
+                file: docker-qemu-smoke/image-id
+              - put: docker-qemu
+                params:
+                  load_file: docker-qemu-smoke/image
+                  load_repository: ((.:docker-qemu-digest))
+                get_params:
+                  skip_download: true
+
+            #@ for arch in archs:
+            - do:
+              - get: #@ "docker-gcc-{}-smoke".format(arch.name)
+                passed:
+                  - #@ "docker-gcc-{}".format(arch.name)
+                params:
+                  save: true
+              - load_var: #@ "docker-gcc-{}-digest".format(arch.name)
+                file: #@ "docker-gcc-{}-smoke/image-id".format(arch.name)
+              - put: #@ "docker-gcc-{}".format(arch.name)
+                params:
+                  load_file: #@ "docker-gcc-{}-smoke/image".format(arch.name)
+                  load_repository: #@ "((.:docker-gcc-{}-digest))".format(arch.name)
+                get_params:
+                  skip_download: true
+            #@ end
+
+  #@ for vendor in debs:
+  #@ for distribution in vendor.distributions:
+  - name: #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+        passed:
+        #@ for test in tests:
+          - #@ test.name
+        #@ end
+
+      - task: docker-pkg-deb
+        privileged: true
+        file: #@ "kraft-{}/.concourse/tasks/build-docker-pkg-deb.yml".format(branch)
+        input_mapping:
+          kraft: #@ "kraft-{}".format(branch)
+        params:
+          BUILD_ARG_PKG_VENDOR: #@ vendor.name
+          BUILD_ARG_PKG_DISTRIBUTION: #@ distribution
+
+      - load_var: docker-pkg-deb-digest
+        file: image/digest
+
+      - put: #@ "docker-pkg-{}-{}-{}".format(vendor.name, distribution, branch)
+        params:
+          load_file: image/image.tar
+          load_repository: ((.:docker-pkg-deb-digest))
+          tag: #@ "{}-{}-{}".format(vendor.name, distribution, branch)
+        get_params:
+          skip_download: true
+  
+  - name: #@ "pkg-{}-{}".format(vendor.name, distribution)
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+        passed:
+          - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+
+      - get: #@ "docker-pkg-{}-{}-{}".format(vendor.name, distribution, branch)
+        passed:
+          - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+
+      - task: pkg-deb
+        file: #@ "kraft-{}/.concourse/tasks/build-pkg-deb.yml".format(branch)
+        image: #@ "docker-pkg-{}-{}-{}".format(vendor.name, distribution, branch)
+        vars:
+          tag: #@ "{}-{}-{}".format(vendor.name, distribution, branch)
+          vendor: #@ vendor.name
+          distribution: #@ distribution
+        input_mapping:
+          kraft: #@ "kraft-{}".format(branch)
+      
+      - load_var: kraft-version
+        file: dist/version
+
+      - put: #@ "{}-{}-deb-smoke".format(vendor.name, distribution)
+        params:
+          source: dist/*.deb
+          destination:
+            - dir: #@ "remote:((releases.deb-dir))"
+              path: #@ "/{}/{}/{}/".format(vendor.name, distribution, "testing")
+              vendor: #@ vendor.name
+              distribution: #@ distribution
+              branch: testing
+  
+  - name: #@ "test-pkg-{}-{}".format(vendor.name, distribution)
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+        passed:
+          - #@ "pkg-{}-{}".format(vendor.name, distribution)
+      
+      - get: #@ "{}-{}-deb-smoke".format(vendor.name, distribution)
+        passed:
+          - #@ "pkg-{}-{}".format(vendor.name, distribution)
+      
+      - load_var: basename
+        file: #@ "{}-{}-deb-smoke/basename".format(vendor.name, distribution)
+
+      - task: test-pkg-deb
+        file: #@ "kraft-{}/.concourse/tasks/test-pkg-deb.yml".format(branch)
+        vars:
+          tag: #@ "{}-{}-{}".format(vendor.name, distribution, branch)
+          vendor: #@ vendor.name
+          distribution: #@ distribution
+          branch: #@ branch
+          basename: ((.:basename))
+        input_mapping:
+          kraft: #@ "kraft-{}".format(branch)
+        on_success:
+          put: #@ "{}-{}-deb".format(vendor.name, distribution)
+          params:
+            source: dist/*.deb
+            destination:
+              - dir: #@ "remote:((releases.deb-dir))"
+                path: #@ "/{}/{}/{}/".format(vendor.name, distribution, "stable")
+                vendor: #@ vendor.name
+                distribution: #@ distribution
+                branch: stable
+
+  #@ end
+  #@ end

--- a/.concourse/templates/staging.yml
+++ b/.concourse/templates/staging.yml
@@ -1,0 +1,390 @@
+#! SPDX-License-Identifier: BSD-3-Clause
+#!
+#! Authors: Alexander Jung <a.jung@lancs.ac.uk>
+#!
+#! Copyright (c) 2020, Lancaster University.  All rights reserved.
+#!
+#! Redistribution and use in source and binary forms, with or without
+#! modification, are permitted provided that the following conditions
+#! are met:
+#!
+#! 1. Redistributions of source code must retain the above copyright
+#!    notice, this list of conditions and the following disclaimer.
+#! 2. Redistributions in binary form must reproduce the above copyright
+#!    notice, this list of conditions and the following disclaimer in the
+#!    documentation and/or other materials provided with the distribution.
+#! 3. Neither the name of the copyright holder nor the names of its
+#!    contributors may be used to endorse or promote products derived from
+#!    this software without specific prior written permission.
+#!
+#! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#! ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#! LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#! POSSIBILITY OF SUCH DAMAGE.
+
+#@ load("@ytt:data",     "data")
+#@ load("@ytt:assert",   "assert")
+#@ load("@ytt:struct",   "struct")
+#! #@ load("unikraft.star", "uk")
+#@ load("mixins.lib.yml", "deb_resource")
+
+#! Template immediate data values
+#@ branch   = data.values.branch or \
+#@            assert.fail("branch must be specified")
+#@ versions = data.values.versions or \
+#@            assert.fail("versions must be specified")
+#@ debs     = data.values.debs or \
+#@            assert.fail("debs must be specified")
+#@ tests    = data.values.tests or \
+#@            assert.fail("tests must be specified")
+#@ archs    = data.values.archs or \
+#@            assert.fail("archs must be specified")
+
+---
+groups:
+  - name: all
+    jobs:
+      - "*"
+  
+  - name: tests
+    jobs:
+      - test-*
+
+  - name: docker
+    jobs:
+      - docker-*
+  
+  #@ for vendor in debs:
+  - name: #@ "pkg-{}".format(vendor.name)
+    jobs:
+      #@ for distribution in vendor.distributions:
+      - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+      - #@ "pkg-{}-{}".format(vendor.name, distribution)
+      - #@ "test-pkg-{}-{}".format(vendor.name, distribution)
+      #@ end
+  #@ end
+
+
+resource_types:
+  - name: docker-image-resource
+    type: docker-image
+    privileged: true
+    source:
+      repository: unikraft/concourse-docker-image-resource
+      tag: latest
+
+  - name: rclone
+    type: docker-image
+    source:
+      repository: ndrjng/concourse-rclone-resource
+      tag: latest
+
+
+resources:
+  - name: #@ "kraft-{}".format(branch)
+    type: git
+    icon: github
+    check_every: 30m
+    webhook_token: ((webhook-token))
+    source:
+      uri: https://github.com/unikraft/kraft.git
+      branch: concourse
+      fetch_tags: true
+
+  - name: docker-qemu
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/qemu
+      tag: #@ "{}-{}".format(versions.qemu, branch)
+
+  #@ for arch in archs:
+  - name: #@ "docker-gcc-{}".format(arch.name)
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/gcc
+      tag: #@ "{}-{}-{}".format(versions.gcc, arch.name, branch)
+  #@ end
+
+  - name: docker-kraft
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/kraft
+      tag: #@ branch
+
+  - name: docker-kraft-dev
+    type: docker-image-resource
+    icon: docker
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/kraft
+      tag: #@ "{}-dev".format(branch)
+
+  #@ for vendor in debs:
+  #@ for distribution in vendor.distributions:
+  - #@ deb_resource(vendor.name, distribution)
+  - name: #@ "docker-pkg-{}-{}-{}".format(vendor.name, distribution, branch)
+    icon: docker
+    type: docker-image-resource
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: unikraft/pkg-deb
+      tag: #@ "{}-{}-{}".format(vendor.name, distribution, branch)
+  #@ end
+  #@ end
+
+jobs:
+  - name: docker-qemu
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+
+      - task: docker-qemu
+        privileged: true
+        file: #@ "kraft-{}/.concourse/tasks/build-docker-qemu.yml".format(branch)
+        input_mapping:
+          kraft: #@ "kraft-{}".format(branch)
+        params:
+          BUILD_ARG_QEMU_VERSION: #@ versions.qemu
+
+      - load_var: docker-qemu-digest
+        file: image/digest
+
+      - put: docker-qemu
+        params:
+          load_file: image/image.tar
+          load_repository: ((.:docker-qemu-digest))
+        get_params:
+          skip_download: true
+
+  #@ for arch in archs:
+  - name: #@ "docker-gcc-{}".format(arch.name)
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+
+      - task: docker-gcc
+        privileged: true
+        file: #@ "kraft-{}/.concourse/tasks/build-docker-gcc.yml".format(branch)
+        input_mapping:
+          kraft: #@ "kraft-{}".format(branch)
+        params:
+          BUILD_ARG_UK_ARCH: #@ arch.name
+          BUILD_ARG_GCC_VERSION: #@ versions.gcc
+          BUILD_ARG_BINUTILS_VERSION: #@ versions.binutils
+          BUILD_ARG_GLIB_VERSION: #@ versions.glib
+
+      - load_var: docker-gcc-digest
+        file: image/digest
+
+      - put: #@ "docker-gcc-{}".format(arch.name)
+        params:
+          load_file: image/image.tar
+          load_repository: ((.:docker-gcc-digest))
+        get_params:
+          skip_download: true
+  #@ end
+
+  - name: docker-kraft
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+        passed:
+          - docker-qemu
+      #@ for arch in archs:
+          - #@ "docker-gcc-{}".format(arch.name)
+      #@ end
+      
+      - get: docker-qemu
+        passed:
+          - docker-qemu
+
+      #@ for arch in archs:
+      - get: #@ "docker-gcc-{}".format(arch.name)
+        passed:
+          - #@ "docker-gcc-{}".format(arch.name)
+      #@ end
+
+      - in_parallel:
+          fail_fast: true
+          steps:
+            
+            #! build the base iamge
+            - do:
+              - task: docker-kraft
+                privileged: true
+                file: #@ "kraft-{}/.concourse/tasks/build-docker-kraft.yml".format(branch)
+                input_mapping:
+                  kraft: #@ "kraft-{}".format(branch)
+                params:
+                  TARGET: kraft
+                  BUILD_ARG_GCC_VERSION: #@ versions.gcc
+
+              - load_var: docker-kraft-digest
+                file: image/digest
+
+              - put: docker-kraft
+                params:
+                  load_file: image/image.tar
+                  load_repository: ((.:docker-kraft-digest))
+                get_params:
+                  skip_download: true
+
+            #! build the developer image
+            - do:
+              - task: docker-kraft-dev
+                privileged: true
+                file: #@ "kraft-{}/.concourse/tasks/build-docker-kraft.yml".format(branch)
+                input_mapping:
+                  kraft: #@ "kraft-{}".format(branch)
+                params:
+                  TARGET: kraft-dev
+                  BUILD_ARG_GCC_VERSION: #@ versions.gcc
+
+              - load_var: docker-kraft-dev-digest
+                file: image/digest
+
+              - put: docker-kraft-dev
+                params:
+                  load_file: image/image.tar
+                  load_repository: ((.:docker-kraft-dev-digest))
+                get_params:
+                  skip_download: true
+
+  #@ for test in tests:
+  - name: #@ test.name
+    plan:
+    - get: #@ "kraft-{}".format(branch)
+      trigger: true
+      version: latest
+      passed:
+        - docker-kraft
+        
+    - get: docker-kraft-dev
+      passed:
+        - docker-kraft
+
+    - task: #@ test.name
+      file: #@ "kraft-{}/.concourse/tasks/test-kraft.yml".format(branch)
+      image: docker-kraft-dev
+      vars:
+        target_cmd: #@ test.cmd
+      input_mapping:
+        kraft: #@ "kraft-{}".format(branch)
+  #@ end
+
+  #@ for vendor in debs:
+  #@ for distribution in vendor.distributions:
+  - name: #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+        passed:
+        #@ for test in tests:
+          - #@ test.name
+        #@ end
+
+      - task: docker-pkg-deb
+        privileged: true
+        file: #@ "kraft-{}/.concourse/tasks/build-docker-pkg-deb.yml".format(branch)
+        input_mapping:
+          kraft: #@ "kraft-{}".format(branch)
+        params:
+          BUILD_ARG_PKG_VENDOR: #@ vendor.name
+          BUILD_ARG_PKG_DISTRIBUTION: #@ distribution
+
+      - load_var: docker-pkg-deb-digest
+        file: image/digest
+
+      - put: #@ "docker-pkg-{}-{}-{}".format(vendor.name, distribution, branch)
+        params:
+          load_file: image/image.tar
+          load_repository: ((.:docker-pkg-deb-digest))
+          tag: #@ "{}-{}-{}".format(vendor.name, distribution, branch)
+        get_params:
+          skip_download: true
+  
+  - name: #@ "pkg-{}-{}".format(vendor.name, distribution)
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+        passed:
+          - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+
+      - get: #@ "docker-pkg-{}-{}-{}".format(vendor.name, distribution, branch)
+        passed:
+          - #@ "docker-pkg-{}-{}".format(vendor.name, distribution)
+
+      - task: pkg-deb
+        file: #@ "kraft-{}/.concourse/tasks/build-pkg-deb.yml".format(branch)
+        image: #@ "docker-pkg-{}-{}-{}".format(vendor.name, distribution, branch)
+        vars:
+          tag: #@ "{}-{}-{}".format(vendor.name, distribution, branch)
+          vendor: #@ vendor.name
+          distribution: #@ distribution
+        input_mapping:
+          kraft: #@ "kraft-{}".format(branch)
+      
+      - load_var: kraft-version
+        file: dist/version
+
+      - put: #@ "{}-{}-deb".format(vendor.name, distribution)
+        params:
+          source: dist/*.deb
+          destination:
+            - dir: #@ "remote:((releases.deb-dir))"
+              path: #@ "/{}/{}/{}/".format(vendor.name, distribution, branch)
+              vendor: #@ vendor.name
+              distribution: #@ distribution
+              branch: #@ branch
+  
+  - name: #@ "test-pkg-{}-{}".format(vendor.name, distribution)
+    plan:
+      - get: #@ "kraft-{}".format(branch)
+        trigger: true
+        version: latest
+        passed:
+          - #@ "pkg-{}-{}".format(vendor.name, distribution)
+      
+      - get: #@ "{}-{}-deb".format(vendor.name, distribution)
+        passed:
+          - #@ "pkg-{}-{}".format(vendor.name, distribution)
+      
+      - load_var: basename
+        file: #@ "{}-{}-deb/basename".format(vendor.name, distribution)
+
+      - task: test-pkg-deb
+        file: #@ "kraft-{}/.concourse/tasks/test-pkg-deb.yml".format(branch)
+        vars:
+          tag: #@ "{}-{}-{}".format(vendor.name, distribution, branch)
+          vendor: #@ vendor.name
+          distribution: #@ distribution
+          branch: #@ branch
+          basename: ((.:basename))
+        input_mapping:
+          kraft: #@ "kraft-{}".format(branch)
+
+  #@ end
+  #@ end

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 dist/
 .tox/
 *.pyc
+.concourse/pipelines/

--- a/package/docker/Dockerfile.kraft
+++ b/package/docker/Dockerfile.kraft
@@ -149,6 +149,8 @@ WORKDIR /usr/src/kraft
 
 RUN set -xe; \
 		pip install -r ./requirements-dev.txt; \
+    apt-get install -y --no-install-recommends \
+      jq; \
     wget -O /usr/bin/ytt https://github.com/vmware-tanzu/carvel-ytt/releases/download/v${YTT_VERSION}/ytt-linux-amd64; \
     wget -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
 

--- a/package/docker/Dockerfile.kraft
+++ b/package/docker/Dockerfile.kraft
@@ -136,6 +136,8 @@ ENTRYPOINT [ "kraft" ]
 
 FROM kraft AS kraft-dev
 
+ARG YTT_VERSION=0.30.0
+
 COPY tests /usr/src/kraft/tests
 COPY tox.ini /usr/src/kraft/tox.ini
 COPY Makefile /usr/src/kraft/Makefile
@@ -145,6 +147,7 @@ COPY requirements-pkg-deb.txt /usr/src/kraft/requirements-pkg-deb.txt
 WORKDIR /usr/src/kraft
 
 RUN set -xe; \
-		pip install -r ./requirements-dev.txt
+		pip install -r ./requirements-dev.txt; \
+    wget -O /usr/bin/ytt https://github.com/vmware-tanzu/carvel-ytt/releases/download/v${YTT_VERSION}/ytt-linux-amd64
 
 ENTRYPOINT [ "" ]

--- a/package/docker/Dockerfile.kraft
+++ b/package/docker/Dockerfile.kraft
@@ -137,6 +137,7 @@ ENTRYPOINT [ "kraft" ]
 FROM kraft AS kraft-dev
 
 ARG YTT_VERSION=0.30.0
+ARG YQ_VERSION=3.4.1
 
 COPY tests /usr/src/kraft/tests
 COPY tox.ini /usr/src/kraft/tox.ini
@@ -148,6 +149,7 @@ WORKDIR /usr/src/kraft
 
 RUN set -xe; \
 		pip install -r ./requirements-dev.txt; \
-    wget -O /usr/bin/ytt https://github.com/vmware-tanzu/carvel-ytt/releases/download/v${YTT_VERSION}/ytt-linux-amd64
+    wget -O /usr/bin/ytt https://github.com/vmware-tanzu/carvel-ytt/releases/download/v${YTT_VERSION}/ytt-linux-amd64; \
+    wget -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
 
 ENTRYPOINT [ "" ]

--- a/package/docker/Dockerfile.kraft
+++ b/package/docker/Dockerfile.kraft
@@ -152,6 +152,8 @@ RUN set -xe; \
     apt-get install -y --no-install-recommends \
       jq; \
     wget -O /usr/bin/ytt https://github.com/vmware-tanzu/carvel-ytt/releases/download/v${YTT_VERSION}/ytt-linux-amd64; \
-    wget -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
+    chmod +x /usr/bin/ytt; \
+    wget -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64; \
+    chmod +x /usr/bin/yq
 
 ENTRYPOINT [ "" ]


### PR DESCRIPTION
This PR includes tools, scripts and templates for CI/CD pipelines for kraft based on [Concourse](https://concourse-ci.org/) which is hosted for the Unikraft OSS project at https://concourse.unikraft.org.  The pipelines themselves serve for packaging, testing and distributing kraft.  Currently this is limited to a suite of Docker images and a few `.deb`s for LTS Ubuntu/Debian distributions.




## Pipelines

There are 3 pipelines, 2 are based on the two primary branches of the kraft repository (`stable` and `staging`) and the last pipeline is designed for all PRs made here on GitHub.  Of the three pipelines, all generate similar artifacts (iterated in detail below).  For now, there are two categories: Docker images and Debian/Ubuntu distributables.

For Docker images, a fully packaged environment is prepared under `unikraft/kraft` available from [docker.io](https://hub.docker.com/r/unikraft/kraft).  For Debian images, a seperate APT repository is hosted at http://releases.unikraft.org which can be used like:

```bash
sudo add-apt-repository \
   "deb [arch=amd64] http://releases.unikraft.org/linux/$DISTRO \
   $(lsb_release -cs) \
   $PIPELINE"
```

Where `$DISTRO` is either `ubuntu` or `debian` and `$PIPELINE` is one of the three listed below:

### `stable` branch

![image](https://user-images.githubusercontent.com/905927/112948924-ef110c00-9138-11eb-9d67-91ea45c6a473.png)

This first pipeline is designed to release, as per the branch name, stable versions of kraft dictated by a semver bump.  It prepares `-smoke` candidates of all artifacts which are only released when the relevant test has passed.

#### Distributables

<table>
  <tr>
    <th>Vendor</th>
    <th>Distributable</th>
    <th>Purpose</th>
  </tr>
  <tr>
    <td rowspan="4">Docker</td>
    <td><code>docker.io/unikraft/kraft:latest</code></td>
    <td rowspan="2">The latest stable version of the kraft tool.</td>
  </tr>
  <tr>
    <td><code>docker.io/unikraft/kraft:$APP_VERSION</code></td>
  </tr>
  <tr>
    <td><code>docker.io/unikraft/kraft:latest-dev</code></td>
    <td rowspan="2">The developer release of the <br /> kraft Docker environment, with extra <br /> tools for the maintenance of kraft itself.</td>
  </tr>
  <tr>
    <td><code>docker.io/unikraft/kraft:$APP_VERSION-dev</code></td>
  </tr>
  <tr>
    <td rowspan="3">Ubuntu</td>
    <td><code>unikraft-tools_$APP_VERSION~xenial_all.deb</code></td>
    <td>Xenial (16.04) LTS</td>
  </tr>
  <tr>
    <td><code>unikraft-tools_$APP_VERSION~bionic_all.deb</code></td>
    <td>Bionic (18.04) LTS</td>
  </tr>
  <tr>
    <td><code>unikraft-tools_$APP_VERSION~focal_all.deb</code></td>
    <td>Focal (20.04) LTS</td>
  </tr>
  <tr>
    <td rowspan="2">Debian</td>
    <td><code>unikraft-tools_$APP_VERSION~stretch_all.deb</code></td>
    <td>Stretch 9</td>
  </tr>
  <tr>
    <td><code>unikraft-tools_$APP_VERSION~buster_all.deb</code></td>
    <td>Buster 10 (stable)</td>
  </tr>
</table>

### `staging` branch

<img width="1665" alt="image" src="https://user-images.githubusercontent.com/905927/109193973-3e11fd00-7799-11eb-848c-99b2f9870c63.png">

This next pipeline is targeted towards the latest commits which have just been merged from PRs into the kraft source tree.  These may not necessarily be stable features and so merging into this tree from a PR may still result in errors in the pipeline but is done so to guarantee faster feature access via one of the distrbutables.

#### Distributables

<table>
  <tr>
    <th>Vendor</th>
    <th>Distributable</th>
    <th>Purpose</th>
  </tr>
  <tr>
    <td rowspan="2">Docker</td>
    <td><code>docker.io/unikraft/kraft:staging</code></td>
    <td>The latest staging version of the kraft tool.</td>
  </tr>
  <tr>
    <td><code>docker.io/unikraft/kraft:staging-dev</code></td>
    <td>The developer release of the <br /> kraft Docker environment, with extra <br /> tools for the maintenance of kraft itself.</td>
  </tr>
  <tr>
    <td>Ubuntu</td>
    <td colspan="2" rowspan="2">Same as above but distributed to different APT repositories.</td>
  </tr>
  <tr>
    <td>Debian</td>
  </tr>
</table>

### `testing` Pull Requests (Including this one!)
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/905927/109218811-2c3f5280-77b7-11eb-9222-804072212ce6.png">

<table>
  <tr>
    <th>Vendor</th>
    <th>Distributable</th>
    <th>Purpose</th>
  </tr>
  <tr>
    <td rowspan="2">Docker</td>
    <td><code>docker.io/unikraft/kraft:pr-$PR_ID</code></td>
    <td>The latest staging version of the kraft tool.</td>
  </tr>
  <tr>
    <td><code>docker.io/unikraft/kraft:dev-pr-$PR_ID</code></td>
    <td>The developer release of the <br /> kraft Docker environment, with extra <br /> tools for the maintenance of kraft itself.</td>
  </tr>
  <tr>
    <td>Ubuntu</td>
    <td colspan="2" rowspan="2">Same as above but distributed to different APT repositories.</td>
  </tr>
  <tr>
    <td>Debian</td>
  </tr>
</table>