### PR TITLE
const: add '*.tgz' suffix as a supported tarball

### DIFF
--- a/kraft/const.py
+++ b/kraft/const.py
@@ -98,6 +98,7 @@ TARBALL_SUPPORTED_EXTENSIONS = [
     '.tar.gz',
     '.tar.xz',
     '.tar',
+    '.tgz',
 ]
 
 SOURCEFORGE_PROJECT_NAME = re.compile(


### PR DESCRIPTION
The suffix '*.tgz' is not covered by tarball list. It is leading kraft to a
failure when it tries to download any source saved as a tgz extension as Python3
does. For further information, see the error below:

    [CRITICAL] 'NoneType' object is not callable
    [CRITICAL] Traceback (most recent call last):
      File "/home/julio/.local/lib/python3.8/site-packages/kraft/cmd/up.py", line 207, in cmd_up
        kraft_build(
      File "/usr/lib/python3/dist-packages/click/decorators.py", line 21, in new_func
        return f(get_current_context(), *args, **kwargs)
      File "/home/julio/.local/lib/python3.8/site-packages/kraft/cmd/build.py", line 69, in kraft_build
        app.fetch()
      File "/usr/lib/python3/dist-packages/click/decorators.py", line 21, in new_func
        return f(get_current_context(), *args, **kwargs)
      File "/home/julio/.local/lib/python3.8/site-packages/kraft/app/app.py", line 416, in fetch
        extra.extend(self.list_possible_mirrors())
      File "/home/julio/.local/lib/python3.8/site-packages/kraft/app/app.py", line 395, in list_possible_mirrors
        for mirror in lib.origin_mirrors:
      File "/usr/lib/python3/dist-packages/click/decorators.py", line 21, in new_func
        return f(get_current_context(), *args, **kwargs)
      File "/home/julio/.local/lib/python3.8/site-packages/kraft/lib/lib.py", line 216, in origin_mirrors
        if self.origin_filename is not None:
      File "/home/julio/.local/lib/python3.8/site-packages/kraft/lib/lib.py", line 192, in origin_filename
        elif self.origin_provider is not None and \
      File "/home/julio/.local/lib/python3.8/site-packages/kraft/lib/lib.py", line 251, in origin_provider
        self._origin_provider = provider_cls(
    TypeError: 'NoneType' object is not callable

The URL used is https://www.python.org/ftp/python/$(LIBPYTHON3_VERSION_LONG)/$(LIBPYTHON3_BASENAME).tgz

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>