### PR TITLE
Solve arm64 kraft errors

### DIFF
--- a/kraft/plat/runner/kvm.py
+++ b/kraft/plat/runner/kvm.py
@@ -33,6 +33,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import subprocess
+import platform
 
 import kraft.util as util
 from .runner import Runner
@@ -67,8 +68,8 @@ class KVMRunner(Runner):
         elif self.architecture == "arm64":
             self._cmd.extend(('-t', 'arm64v'))
 
-        # if platform.machine() != self.architecture:
-        #     self._cmd.append('-W')
+        if platform.machine() != self.architecture:
+            self._cmd.append('-W')
 
         if self.arguments:
             self._cmd.extend(('-a', self.arguments))

--- a/package/docker/Dockerfile.gcc
+++ b/package/docker/Dockerfile.gcc
@@ -143,3 +143,4 @@ COPY --from=gcc-build /out/bin/ /bin/
 COPY --from=gcc-build /out/include/ /include/
 COPY --from=gcc-build /out/lib/ /lib/
 COPY --from=gcc-build /out/libexec/ /libexec/
+COPY --from=gcc-build /out/aarch64-linux-gnu/ /aarch64-linux-gnu/

--- a/package/docker/Dockerfile.gcc
+++ b/package/docker/Dockerfile.gcc
@@ -143,4 +143,4 @@ COPY --from=gcc-build /out/bin/ /bin/
 COPY --from=gcc-build /out/include/ /include/
 COPY --from=gcc-build /out/lib/ /lib/
 COPY --from=gcc-build /out/libexec/ /libexec/
-COPY --from=gcc-build /out/aarch64-linux-gnu/ /aarch64-linux-gnu/
+COPY --from=gcc-build /out/${GCC_PREFIX} /${GCC_PREFIX}

--- a/package/docker/Dockerfile.kraft
+++ b/package/docker/Dockerfile.kraft
@@ -53,9 +53,10 @@ COPY --from=gcc-arm /bin/               /bin
 COPY --from=gcc-arm /lib/gcc/           /lib/gcc
 COPY --from=gcc-arm /libexec/gcc/       /libexec/gcc
 
-COPY --from=gcc-arm64 /bin/             /bin
-COPY --from=gcc-arm64 /lib/gcc/         /lib/gcc
-COPY --from=gcc-arm64 /libexec/gcc/     /libexec/gcc
+COPY --from=gcc-arm64 /bin/               /bin
+COPY --from=gcc-arm64 /lib/gcc/           /lib/gcc
+COPY --from=gcc-arm64 /libexec/gcc/       /libexec/gcc
+COPY --from=gcc-arm64 /aarch64-linux-gnu/ /aarch64-linux-gnu
 
 RUN set -xe; \
     ln -s /bin/${GCC_PREFIX}-as         /bin/as; \
@@ -82,6 +83,7 @@ RUN set -xe; \
     ln -s /bin/${GCC_PREFIX}-size       /bin/size; \
     ln -s /bin/${GCC_PREFIX}-strings    /bin/strings; \
     ln -s /bin/${GCC_PREFIX}-strip      /bin/strip;
+
 
 COPY --from=qemu /bin/                  /bin
 COPY --from=qemu /share/qemu/           /share/qemu

--- a/package/docker/Dockerfile.kraft
+++ b/package/docker/Dockerfile.kraft
@@ -44,14 +44,17 @@ FROM python:3.6-slim AS kraft
 
 ARG GCC_PREFIX=x86_64-linux-gnu
 
-COPY --from=gcc-x86_64 /bin/            /bin
-COPY --from=gcc-x86_64 /lib/gcc/        /lib/gcc
-COPY --from=gcc-x86_64 /include/        /include
-COPY --from=gcc-x86_64 /libexec/gcc/    /libexec/gcc
+COPY --from=gcc-x86_64 /bin/              /bin
+COPY --from=gcc-x86_64 /lib/gcc/          /lib/gcc
+COPY --from=gcc-x86_64 /include/          /include
+COPY --from=gcc-x86_64 /libexec/gcc/      /libexec/gcc
+COPY --from=gcc-x86_64 /x86_64-linux-gnu  /x86_64-linux-gnu
 
-COPY --from=gcc-arm /bin/               /bin
-COPY --from=gcc-arm /lib/gcc/           /lib/gcc
-COPY --from=gcc-arm /libexec/gcc/       /libexec/gcc
+COPY --from=gcc-arm /bin/                 /bin
+COPY --from=gcc-arm /lib/gcc/             /lib/gcc
+COPY --from=gcc-arm /libexec/gcc/         /libexec/gcc
+COPY --from=gcc-arm /arm-linux-gnueabihf  /arm-linux-gnueabihf
+
 
 COPY --from=gcc-arm64 /bin/               /bin
 COPY --from=gcc-arm64 /lib/gcc/           /lib/gcc
@@ -83,7 +86,6 @@ RUN set -xe; \
     ln -s /bin/${GCC_PREFIX}-size       /bin/size; \
     ln -s /bin/${GCC_PREFIX}-strings    /bin/strings; \
     ln -s /bin/${GCC_PREFIX}-strip      /bin/strip;
-
 
 COPY --from=qemu /bin/                  /bin
 COPY --from=qemu /share/qemu/           /share/qemu


### PR DESCRIPTION
This PR comes to solve issue https://github.com/unikraft/kraft/issues/57. There are two problems with kraft on ARM64, solved by two different commits:

- `kraft build` uses `aarch64-linux-gnu-gcc`, which in turn calls the x86_64 assembler, resulting in a build error. At first, I was thinking about replacing the current arm64 toolchain with the linaro one (as mentioned in a previous comment). Finally, I managed to solve this by adding a missing directory (`aarch64-linux-gnu`) to the final kraft container. This way, we don't need to add linaro anymore.
In order for this to work fine, I think we should also update the `unikraft/gcc:9.2.0-arm64-staging` image from docker hub[1].

- `kraft run` is always trying to enable hardware acceleration, even if the host architecture is different from the emulated one. This generates errors when trying to emulate ARM64 images on x86 hosts. The problem can be easily solved by checking the architecture in `kvm.py` and  generating the right qemu command.

[1]https://hub.docker.com/layers/unikraft/gcc/9.2.0-arm64/images/sha256-3fd1ce6b6f7acb9e259212bf922b8b2090f10cf0e93621f94f04c51a92a5835e?context=explore

Signed-off-by: Răzvan Vîrtan <virtanrazvan@gmail.com>
