### PR TITLE
Use local gcc images when building the kraft image in the CI/CD system

### DIFF
--- a/.concourse/templates/pr.yml
+++ b/.concourse/templates/pr.yml
@@ -287,6 +287,7 @@ jobs:
                 params:
                   BUILD_ARG_GCC_VERSION: pr-((.:pull-request-number))
                   BUILD_ARG_QEMU_VERSION: pr-((.:pull-request-number))
+                  BUILD_ARG_USE_LOCAL: "yes"
                 on_success: #@ pull_request_status("success", "docker-kraft", "Successfully built unikraft/kraft:pr-((.:pull-request-number))")
                 on_failure: #@ pull_request_status("failure", "docker-kraft", "Failed to build unikraft/kraft:pr-((.:pull-request-number))")
 

--- a/package/docker/Dockerfile.kraft
+++ b/package/docker/Dockerfile.kraft
@@ -32,11 +32,12 @@
 ARG UK_ARCH=x86_64
 ARG GCC_VERSION=9.2.0
 ARG QEMU_VERSION=4.2.0
+ARG LOCAL_TAG
 
-FROM unikraft/gcc:${GCC_VERSION}-x86_64 AS gcc-x86_64
-FROM unikraft/gcc:${GCC_VERSION}-arm    AS gcc-arm
-FROM unikraft/gcc:${GCC_VERSION}-arm64  AS gcc-arm64
-FROM unikraft/qemu:${QEMU_VERSION}      AS qemu
+FROM unikraft/gcc:${GCC_VERSION}-x86_64${LOCAL_TAG} AS gcc-x86_64
+FROM unikraft/gcc:${GCC_VERSION}-arm${LOCAL_TAG}    AS gcc-arm
+FROM unikraft/gcc:${GCC_VERSION}-arm64${LOCAL_TAG}  AS gcc-arm64
+FROM unikraft/qemu:${QEMU_VERSION}${LOCAL_TAG}      AS qemu
 
 LABEL MAINTAINER="Alexander Jung <alexander.jung@neclab.eu>"
 

--- a/package/docker/Makefile
+++ b/package/docker/Makefile
@@ -218,6 +218,11 @@ docker-kraft: IMAGE_NAME ?= $(ORG)/$(APP_NAME):$(IMAGE_VERSION)-dev
 else
 docker-kraft: IMAGE_NAME ?= $(ORG)/$(APP_NAME):$(IMAGE_VERSION)
 endif
+ifeq ($(USE_LOCAL),yes)
+docker-kraft: LOCAL_TAG ?= -$(TAG)
+else
+docker-kraft: LOCAL_TAG ?=
+endif
 docker-kraft:
 ifneq (,$(findstring help,$(MAKECMDGOALS)))
 	@echo "Usage: [IMAGE_VERSION=... IMAGE_NAME=...] $(MAKE) $@                            "
@@ -242,6 +247,7 @@ else
 		--build-arg UK_ARCH=$(UK_ARCH) \
 		--build-arg GCC_VERSION=$(GCC_VERSION) \
 		--build-arg QEMU_VERSION=$(QEMU_VERSION) \
+		--build-arg LOCAL_TAG=$(LOCAL_TAG) \
 		--cache-from $(ORG)/$(APP_NAME):latest \
 		--cache-from $(IMAGE_NAME) \
 		--file $(DOCKERDIR)/Dockerfile.kraft \


### PR DESCRIPTION
Until now, the kraft dockerfile tried to get gcc images with the following name:
`unikraft/gcc:${GCC_VERSION}-${UK_ARCH}`. This naming format ignores the local tag generated
when compiling the gcc container images. Therefore, `make docker-kraft` is always using
the gcc images from docker hub.

This situation can cause problems for the CI/CD system when a PR brings changes to the
gcc containers. The modifications can't be used when building the kraft image, since it uses the old
docker hub verisons of gcc.

This commit adds an environment variable called `USE_LOCAL` to the `make docker-kraft` command.
When `USE_LOCAL` is set to "yes", the kraft build process will try to get gcc images with names ending
in the local tag. This way, we will find gcc images compiled locally, at a previous step. If `USE_LOCAL`
is not set, things work as before.

`USE_LOCAL` should always be set to "yes" when running the PR pipeline.

Signed-off-by: Razvan Virtan <virtanrazvan@gmail.com>