### PR TITLE
Introduce command to remove library from project

### DIFF
--- a/kraft/app/app.py
+++ b/kraft/app/app.py
@@ -33,6 +33,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os
+import shutil
 import subprocess
 import tarfile
 import tempfile
@@ -388,6 +389,35 @@ class Application(Component):
                     version=version,
                     manifest=manifest,
                 ))
+
+        self.save_yaml()
+
+        return True
+
+    @click.pass_context
+    def remove_lib(ctx, self, lib=None, purge=False):
+        if lib is None or str(lib) == "":
+            logger.warn("No library to remove")
+            return False
+
+        elif isinstance(lib, six.string_types):
+            _, name, _, _ = break_component_naming_format(lib)
+            manifests = maniest_from_name(name)
+
+            if len(manifests) == 0:
+                logger.warn("Unknown library: %s" % lib)
+                return False
+
+            for manifest in manifests:
+                if manifest.type != ComponentType.LIB:
+                    continue
+
+                self.config.libraries.remove(name, purge)
+                break
+
+            if purge and os.path.exists(manifest.localdir):
+                logger.info("Purging lib/%s..." % name)
+                shutil.rmtree(manifest.localdir)
 
         self.save_yaml()
 

--- a/kraft/app/app.py
+++ b/kraft/app/app.py
@@ -383,7 +383,6 @@ class Application(Component):
                 if manifest.type != ComponentType.LIB:
                     continue
 
-                logger.info("Adding %s@%s" % (manifest, version))
                 self.config.libraries.add(Library(
                     name=name,
                     version=version,

--- a/kraft/cmd/lib/__init__.py
+++ b/kraft/cmd/lib/__init__.py
@@ -37,6 +37,7 @@ import click
 from .add import cmd_lib_add
 from .bump import cmd_lib_bump
 from .init import cmd_lib_init
+from .remove import cmd_lib_remove
 
 
 @click.group(name='lib', short_help='Unikraft library commands.')
@@ -52,3 +53,4 @@ def grp_lib(ctx):
 grp_lib.add_command(cmd_lib_bump)
 grp_lib.add_command(cmd_lib_init)
 grp_lib.add_command(cmd_lib_add)
+grp_lib.add_command(cmd_lib_remove)

--- a/kraft/cmd/lib/add.py
+++ b/kraft/cmd/lib/add.py
@@ -39,7 +39,6 @@ import click
 
 from kraft.app import Application
 from kraft.cmd.list import kraft_list_pull
-from kraft.const import UNIKRAFT_WORKDIR
 from kraft.logger import logger
 
 
@@ -72,13 +71,13 @@ def kraft_lib_add(ctx, workdir=None, lib=None):
     metavar="PATH"
 )
 @click.option(
-    '--dump', '-d', 'dumps_local',
+    '--pull/--no-pull', 'pull',
     help='Save libraries into project directory.',
-    is_flag=True,
+    default=True,
 )
 @click.argument('lib', required=False, nargs=-1)
 @click.pass_context
-def cmd_lib_add(ctx, workdir=None, lib=None, dumps_local=False):
+def cmd_lib_add(ctx, workdir=None, lib=None, pull=False):
     """
     Add a library to the unikraft application project.
     """
@@ -87,10 +86,9 @@ def cmd_lib_add(ctx, workdir=None, lib=None, dumps_local=False):
         workdir = os.getcwd()
 
     try:
-        if dumps_local:
+        if pull:
             kraft_list_pull(
-                name=lib,
-                workdir=os.path.join(workdir, UNIKRAFT_WORKDIR)
+                name=lib
             )
 
         if not kraft_lib_add(workdir=workdir, lib=lib):

--- a/kraft/cmd/lib/remove.py
+++ b/kraft/cmd/lib/remove.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Authors: Alexander Jung <a.jung@lancs.ac.uk>
+#
+# Copyright (c) 2021, Lancaster University.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+import sys
+
+import click
+
+from kraft.app import Application
+from kraft.logger import logger
+
+
+@click.pass_context
+def kraft_lib_remove(ctx, workdir=None, lib=None, purge=False):
+    if workdir is None or os.path.exists(workdir) is False:
+        raise ValueError("working directory is empty: %s" % workdir)
+
+    if isinstance(lib, tuple):
+        lib = list(lib)
+
+    if isinstance(lib, list):
+        for l in lib:  # noqa: E741
+            if not kraft_lib_remove(workdir, l, purge):
+                return False
+        return True
+
+    app = Application.from_workdir(
+        workdir,
+        force_init=True,
+        use_versions=[lib]  # override version if already present
+    )
+
+    return app.remove_lib(lib, purge=purge)
+
+
+@click.command('remove', short_help='Remove a library from the project.')
+@click.option(
+    '--workdir', '-w', 'workdir',
+    help='Specify an alternative directory for the application [default is cwd].',
+    metavar="PATH"
+)
+@click.option(
+    '--purge', '-P', 'purge',
+    help='Removes the source files for the library.',
+    is_flag=True,
+)
+@click.argument('lib', required=False, nargs=-1)
+@click.pass_context
+def cmd_lib_remove(ctx, workdir=None, lib=None, purge=False):
+    """
+    Remove a library from the unikraft application project.
+    """
+
+    if workdir is None:
+        workdir = os.getcwd()
+
+    try:
+        if not kraft_lib_remove(workdir=workdir, lib=lib, purge=purge):
+            sys.exit(1)
+
+    except Exception as e:
+        if ctx.obj.verbose:
+            import traceback
+            logger.critical(traceback.format_exc())
+        else:
+            logger.critical(str(e))
+
+        sys.exit(1)

--- a/kraft/component.py
+++ b/kraft/component.py
@@ -33,6 +33,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os
+import shutil
 
 import click
 import kconfiglib
@@ -340,6 +341,26 @@ class ComponentManager(object):
             raise TypeError("expected Component")
 
         self._components.append(component)
+
+    def remove(self, component=None, purge=False):
+        if component is None:
+            raise ValueError("expected component")
+
+        if isinstance(component, six.string_types):
+            for i, c in enumerate(self._components):
+                if c.name == component:
+                    if purge and os.path.exists(c.localdir):
+                        logger.info("Purging lib/%s..." % component)
+                        shutil.rmtree(c.localdir)
+
+                    else:
+                        logger.info("Removing lib/%s..." % component)
+
+                    del self._components[i]
+
+                    return True
+
+        return False
 
     def get(self, name=None):
         for component in self._components:

--- a/kraft/component.py
+++ b/kraft/component.py
@@ -340,7 +340,11 @@ class ComponentManager(object):
         if not isinstance(component, Component):
             raise TypeError("expected Component")
 
+        logger.info("Adding %s@%s..." % (component.manifest, component.version))
+
         self._components.append(component)
+
+        return True
 
     def remove(self, component=None, purge=False):
         if component is None:


### PR DESCRIPTION
This commit series intoduces a new command `kraft lib remove` which allows the developer to remove a library from the project.