### PR TITLE
Fix arm `kraft build` and `kraft run` errors

### DIFF
--- a/kraft/plat/runner/kvm.py
+++ b/kraft/plat/runner/kvm.py
@@ -33,6 +33,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import subprocess
+import platform
 
 import kraft.util as util
 from .runner import Runner
@@ -67,8 +68,8 @@ class KVMRunner(Runner):
         elif self.architecture == "arm64":
             self._cmd.extend(('-t', 'arm64v'))
 
-        # if platform.machine() != self.architecture:
-        #     self._cmd.append('-W')
+        if platform.machine() != self.architecture:
+            self._cmd.append('-W')
 
         if self.arguments:
             self._cmd.extend(('-a', self.arguments))

--- a/package/docker/Dockerfile.gcc
+++ b/package/docker/Dockerfile.gcc
@@ -143,3 +143,4 @@ COPY --from=gcc-build /out/bin/ /bin/
 COPY --from=gcc-build /out/include/ /include/
 COPY --from=gcc-build /out/lib/ /lib/
 COPY --from=gcc-build /out/libexec/ /libexec/
+COPY --from=gcc-build /out/${GCC_PREFIX} /${GCC_PREFIX}

--- a/package/docker/Dockerfile.kraft
+++ b/package/docker/Dockerfile.kraft
@@ -44,18 +44,22 @@ FROM python:3.6-slim AS kraft
 
 ARG GCC_PREFIX=x86_64-linux-gnu
 
-COPY --from=gcc-x86_64 /bin/            /bin
-COPY --from=gcc-x86_64 /lib/gcc/        /lib/gcc
-COPY --from=gcc-x86_64 /include/        /include
-COPY --from=gcc-x86_64 /libexec/gcc/    /libexec/gcc
+COPY --from=gcc-x86_64 /bin/              /bin
+COPY --from=gcc-x86_64 /lib/gcc/          /lib/gcc
+COPY --from=gcc-x86_64 /include/          /include
+COPY --from=gcc-x86_64 /libexec/gcc/      /libexec/gcc
+COPY --from=gcc-x86_64 /x86_64-linux-gnu  /x86_64-linux-gnu
 
-COPY --from=gcc-arm /bin/               /bin
-COPY --from=gcc-arm /lib/gcc/           /lib/gcc
-COPY --from=gcc-arm /libexec/gcc/       /libexec/gcc
 
-COPY --from=gcc-arm64 /bin/             /bin
-COPY --from=gcc-arm64 /lib/gcc/         /lib/gcc
-COPY --from=gcc-arm64 /libexec/gcc/     /libexec/gcc
+COPY --from=gcc-arm /bin/                 /bin
+COPY --from=gcc-arm /lib/gcc/             /lib/gcc
+COPY --from=gcc-arm /libexec/gcc/         /libexec/gcc
+COPY --from=gcc-arm /arm-linux-gnueabihf  /arm-linux-gnueabihf
+
+COPY --from=gcc-arm64 /bin/               /bin
+COPY --from=gcc-arm64 /lib/gcc/           /lib/gcc
+COPY --from=gcc-arm64 /libexec/gcc/       /libexec/gcc
+COPY --from=gcc-arm64 /aarch64-linux-gnu/ /aarch64-linux-gnu
 
 RUN set -xe; \
     ln -s /bin/${GCC_PREFIX}-as         /bin/as; \


### PR DESCRIPTION
This pull requests comes to solve two problems related to the `kraft ` command, more frequent on ARM64:
- When running `kraft build` in the docker environment, errors appear because we miss directories like  `aarch64-gnu-gcc` and kraft is trying to use the default compiler of the host architecture. We solve this by adding the missing directories to the `docker-kraft` image.
- When running `kraft run`, we always enable hardware acceleration, generating failures when we run an image compiled for an architecture different from the host one. We solve this by checking the host architecture when generating the `qemu` command.
 
This PR should also solve the CI / CD errors that always appear on ARM64.

Signed-off-by: Răzvan Vîrtan <virtanrazvan@gmail.com>