### PR TITLE
Add GCC and QEMU version parameters to docker-kraft-dev task

### DIFF
--- a/.concourse/templates/pr.yml
+++ b/.concourse/templates/pr.yml
@@ -313,6 +313,8 @@ jobs:
                   kraft: pull-request
                 params:
                   TARGET: kraft-dev
+                  BUILD_ARG_GCC_VERSION: pr-((.:pull-request-number))
+                  BUILD_ARG_QEMU_VERSION: pr-((.:pull-request-number))
                 on_success: #@ pull_request_status("success", "docker-kraft-dev", "Successfully built unikraft/kraft:dev-pr-((.:pull-request-number))")
                 on_failure: #@ pull_request_status("failure", "docker-kraft-dev", "Failed to build unikraft/kraft:dev-pr-((.:pull-request-number))")
 


### PR DESCRIPTION
At this moment, the CI / CD pipeline is running  `make docker-kraft TARGET=kraft-dev`,
without setting `GCC_VERSION` and `QEMU_VERSION` arguments. This results in old
`docker-gcc` and `docker-qemu` images being used when copying files to `docker-kraft`.

Most of the time, this is not a problem, but when we create  PRs that bring changes
to the `docker-gcc` or `docker-qemu` tasks, we may get misleading failures.

This PR adds the missing version parameters to the `docker-kraft-dev` task (as we
do for the simple `docker-kraft`).

Signed-off-by: Răzvan Vîrtan <virtanrazvan@gmail.com>