### PR TITLE
Resolve out of range error

### DIFF
--- a/kraft/cmd/run.py
+++ b/kraft/cmd/run.py
@@ -88,6 +88,9 @@ def kraft_run(ctx, appdir=None, target=None, plat=None, arch=None, initrd=None,
 
             binaries.append(binname)
 
+        if(len(binaries) == 0):
+            raise ValueError("Unikernel binary not found.(Please check that your application name is the same as directory name)")
+
         target_answer = None
 
         binaries = list(set(binaries))

--- a/kraft/cmd/run.py
+++ b/kraft/cmd/run.py
@@ -88,8 +88,8 @@ def kraft_run(ctx, appdir=None, target=None, plat=None, arch=None, initrd=None,
 
             binaries.append(binname)
 
-        if(len(binaries) == 0):
-            raise ValueError("Unikernel binary not found.(Please check that your application name is the same as directory name)")
+        if (len(binaries) == 0):
+            raise ValueError("Unikernel binary not found. Please check that your application name (in the kraft.yaml file) is the same as directory name.")
 
         target_answer = None
 


### PR DESCRIPTION
Add a check for `out of range` error if the name of the base directory is different from the name of the application from kraft.yaml.


Github-Pull-Request-Closes: #80 
Signed-off-by: Gabriel Mocanu <gabi.mocanu98@gmail.com>