### PR TITLE
cmd,app: Fix fast builds

### DIFF
--- a/kraft/cmd/build.py
+++ b/kraft/cmd/build.py
@@ -62,8 +62,9 @@ def kraft_build(ctx, verbose=False, workdir=None, fetch=True, prepare=True,
 
     n_proc = None
     if fast:
-        # This simply set the `-j` flag which signals to make to use all cores.
-        n_proc = 0
+        # This simply set the `-j` flag to -1 which signals to make to use all
+        # cores.
+        n_proc = -1
 
     if fetch:
         app.fetch()
@@ -72,7 +73,10 @@ def kraft_build(ctx, verbose=False, workdir=None, fetch=True, prepare=True,
         app.prepare()
 
     if progress:
-        return_code = make_progressbar(app.make_raw(verbose=verbose))
+        return_code = make_progressbar(app.make_raw(
+            verbose=verbose,
+            n_proc=n_proc
+        ))
 
     else:
         return_code = app.build(


### PR DESCRIPTION
Fix the `--fast` flag in `kraft build`.  This flag facilitates the `make -j` sub-command and the current implementation had a bug where it did not pass the flag because it is also possible to set how many cores are to be used via the same `--fast` flag.  Niavely, `fast` was set to `0` which made all if conditions for adding `-n` be false.