### PR TITLE
A tricky fix for binname/appname not matched bug (#80 and #83).

### DIFF
--- a/kraft/app/app.py
+++ b/kraft/app/app.py
@@ -355,6 +355,10 @@ class Application(Component):
         try:
             return_code = self.make([
                 ('UK_DEFCONFIG=%s' % path),
+                # see #80 and #83, the fallback behavior once name field is missing in the original kraft.yaml
+                # is to use the parent folder name, and the missing field will be automatically complemented
+                # (ensured by config.load_config() implementation)
+                ('CONFIG_UK_NAME=%s' % self.config.name),
                 'defconfig'
             ])
         finally:


### PR DESCRIPTION
My solution is somehow tricky and may not be such elegant, but at least it works.

Tests are passed under cases when the name field in kraft.yaml is provided with arbitrary value or even missing, but a null value (like `name :` without value provided) will not work because such case is regarded as invalid by the yaml parser.

Signed-off-by: Xiangyi Meng <xymeng16@gmail.com>