### PR TITLE
util/op,plat/network: parse subprocess output as utf-8

### DIFF
--- a/kraft/plat/network/driver/brctl.py
+++ b/kraft/plat/network/driver/brctl.py
@@ -98,7 +98,7 @@ class BRCTLDriver(NetworkDriver):
 
         if err == b"can't get info No such device\n":
             return False
-        elif "does not exist!" in err.decode('ascii'):
+        elif "does not exist!" in err.decode('utf-8'):
             return False
 
         return True

--- a/kraft/util/op.py
+++ b/kraft/util/op.py
@@ -64,7 +64,7 @@ def execute(cmd="", env={}, dry_run=False, use_logger=False):
         )
 
         for line in popen.stdout:
-            line = line.strip().decode('ascii')
+            line = line.strip().decode('utf-8')
             if use_logger:
                 logger.info(line)
             else:
@@ -140,7 +140,7 @@ def make_progressbar(make=""):
 
             for line in popen.stdout:
                 t.update()
-                line = line.strip().decode('ascii')
+                line = line.strip().decode('utf-8')
                 if line.startswith("make: Leaving directory") is False and \
                         line.startswith("make: Entering directory") is False:
                     print(line)


### PR DESCRIPTION
Fixes https://github.com/unikraft/kraft/issues/96

Note: the default encoding for `decode` is `UTF-8` so that's why I omitted it, but it can be made explicit if preferred.