### PR TITLE
scripts: Run QEMU as normal user

### DIFF
--- a/scripts/qemu-guest
+++ b/scripts/qemu-guest
@@ -354,28 +354,15 @@ _netdev_hwaddr()
 }
 
 ##
-## ARE WE ROOT?
-##
-if [ $( id -u ) != 0 ]; then
-	if [ -x $( which sudo ) ]; then
-		echo "Trying to get root privileges..." 1>&2
-		exec sudo "$0" "$@"
-		exit 2
-	fi
-
-	echo "Please run as root" 1>&2
-	exit 1
-fi
-
-##
 ## MAIN
 ##
 QEMU_BASE_ARGS=()
 QEMU_ARGS=()
 QEMU_PID=
-SOCK_MONITOR="/run/$( basename "$0" )-$$_monitor.socket"
-SOCK_SERIAL="/run/$( basename "$0" )-$$_serial.socket"
-PIDFILE="/run/$( basename "$0" )-$$_qemu.pid"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run}"
+SOCK_MONITOR="$RUNTIME_DIR/$( basename "$0" )-$$_monitor.socket"
+SOCK_SERIAL="$RUNTIME_DIR/$( basename "$0" )-$$_serial.socket"
+PIDFILE="$RUNTIME_DIR/$( basename "$0" )-$$_qemu.pid"
 TEMP="/tmp/$( basename "$0" )-$$"
 
 ARG_MACHINETYPE="x86pc"


### PR DESCRIPTION
On some systems it is possible to run QEMU as normal user. The only things which stop us from doing so are the check at beginning of `qemu-guest` and that `/run` might not be writable. This patch takes care of both points (tested on Debian bookworm).

Signed-off-by: George Hopkins <george-hopkins@null.net