### PR TITLE
cmd/list/provider: Fix repository name

### DIFF
--- a/kraft/cmd/list/provider/github.py
+++ b/kraft/cmd/list/provider/github.py
@@ -185,7 +185,9 @@ def get_component_from_github(ctx, origin=None, org=None, repo=None):
     from .types import ListProviderType
 
     if isinstance(repo, str):
-        if ".git" in repo:
+        if repo == '.github':
+            pass
+        elif ".git" in repo:
             repo = repo.split(".")[0]
         github_api = Github(ctx.obj.env.get('UK_KRAFT_GITHUB_TOKEN', None))
         repo = github_api.get_repo(


### PR DESCRIPTION
This problem is related to the [repo](https://github.com/unikraft/.github) for the organization because of the naming convention from Github.
The previous code converted the repo name to an empty string after `split` function.
I hardcoded that value because I don't think we will have more repos with this naming convention.
Another solution would be to use `startswith` function or to exclude the whole logic of split because I saw we don't have any repository that ends with `.git` and the `repo` variable is always the name of the repository without `.git`.

Signed-off-by: Gabriel Mocanu <gabi.mocanu98@gmail.com>