### PR TITLE
Add option to invoke QEMU with SGX support

### DIFF
--- a/kraft/app/app.py
+++ b/kraft/app/app.py
@@ -513,7 +513,7 @@ class Application(Component):
     def run(self, target=None, initrd=None, background=False,  # noqa: C901
             paused=False, gdb=4123, dbg=False, virtio_nic=None, bridge=None,
             interface=None, dry_run=False, args=None, memory=64, cpu_sockets=1,
-            cpu_cores=1):
+            cpu_cores=1, epc_size=64):
 
         if target is None:
             raise KraftError('Target not set')
@@ -553,6 +553,9 @@ class Application(Component):
 
         if cpu_cores:
             runner.set_cpu_cores(cpu_cores)
+
+        if epc_size:
+            runner.add_sgx(epc_size)
 
         for volume in self.config.volumes.all():
             if volume.driver is VolumeDriver.VOL_9PFS:

--- a/kraft/const.py
+++ b/kraft/const.py
@@ -168,7 +168,6 @@ UK_VERSION_VARNAME = '$(%s_VERSION)'
 
 UK_CORE_ARCHS = [
     'x86_64',
-    'x86_64-sgx'
     'arm64',
     'arm',
 ]

--- a/kraft/const.py
+++ b/kraft/const.py
@@ -168,6 +168,7 @@ UK_VERSION_VARNAME = '$(%s_VERSION)'
 
 UK_CORE_ARCHS = [
     'x86_64',
+    'x86_64-sgx'
     'arm64',
     'arm',
 ]

--- a/kraft/plat/runner/runner.py
+++ b/kraft/plat/runner/runner.py
@@ -201,6 +201,11 @@ class Runner(object):
         if cpu_cores and isinstance(cpu_cores, int):
             self._cmd.extend(('-c', cpu_cores))
 
+    def add_sgx(self, epc_size=None):
+        if epc_size and isinstance(epc_size, int):
+            self._cmd.extend(('-X', '%d' % epc_size))
+
+
     def execute(self, extra_args=None, background=False, paused=False, dry_run=False):
         raise RunnerError('Using undefined runner driver')
 

--- a/scripts/qemu-guest
+++ b/scripts/qemu-guest
@@ -504,6 +504,7 @@ usage()
 	echo "  -k [KERNEL]                Enable direct kernel boot with KERNEL"
 	echo "  -i [INITRD]                Init-ramdisk INITRD for -k"
 	echo "  -a [ARGUMENTS]             Kernel arguments for -k"
+	echo "	-X [SGX-EPC-SIZE]          Enable Intel SGX and set EPC size"
 	echo "  -l                         Enable virtio-balloon"
 	echo "  -r                         Enable virtio-rng"
 	echo "  -C                         Do not terminate guest with CTRL-C"
@@ -520,7 +521,7 @@ usage()
 	echo "  $0 -c 2 -m 2048 -b virbr0 -b virbr1 -q root.qcow2 -d /dev/sdb -d /dev/sdc"
 }
 
-while getopts :hnN:b:V:f:G:d:q:S:I:e:k:i:a:c:m:v:lrs:p:HxCDG:g:PT:WQ:M:t: OPT; do
+while getopts :hnN:b:V:f:G:d:q:S:I:e:k:i:a:X:c:m:v:lrs:p:HxCDG:g:PT:WQ:M:t: OPT; do
         case ${OPT} in
 	v)
 		OPT_VIDEOVNC=0
@@ -673,6 +674,14 @@ EOF
 	a)
 		ARG_APPEND="${OPTARG}"
 		OPT_APPEND=0
+		;;
+	X)
+		QEMU_ARGS+=("-cpu")
+		QEMU_ARGS+=("host,+sgx-provisionkey")
+		QEMU_ARGS+=("-object")
+		QEMU_ARGS+=("memory-backend-epc,id=mem1,size=${OPTARG}M,prealloc=on")
+		QEMU_ARGS+=("-M")
+		QEMU_ARGS+=("sgx-epc.0.memdev=mem1,sgx-epc.0.node=0")
 		;;
 	p)
 		ARG_VCPUPIN=$( _expand_num_list "${OPTARG}" )

--- a/scripts/qemu-guest
+++ b/scripts/qemu-guest
@@ -677,7 +677,7 @@ EOF
 		;;
 	X)
 		QEMU_ARGS+=("-cpu")
-		QEMU_ARGS+=("host,+sgx-provisionkey")
+		QEMU_ARGS+=("host,+sgx1,+sgx-provisionkey")
 		QEMU_ARGS+=("-object")
 		QEMU_ARGS+=("memory-backend-epc,id=mem1,size=${OPTARG}M,prealloc=on")
 		QEMU_ARGS+=("-M")


### PR DESCRIPTION
This PR added an option `-X [SGX-EPC-SIZE]` to qemu-guest, which invokes QEMU with SGX support. But there are two prerequisites:
 - The unikraft repo should have SGX support (https://github.com/unikraft/unikraft/pull/474)
 - QEMU version >= 7.0
 - Host should run Linux with kernel >= 5.13 and SGX virtualization should be enabled (https://www.intel.com/content/www/us/en/developer/articles/technical/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)