### PR TITLE
kraft/cmd: Add option to build on x CPUs

### DIFF
--- a/kraft/cmd/build.py
+++ b/kraft/cmd/build.py
@@ -62,9 +62,7 @@ def kraft_build(ctx, verbose=False, workdir=None, fetch=True, prepare=True,
 
     n_proc = None
     if fast:
-        # This simply set the `-j` flag to -1 which signals to make to use all
-        # cores.
-        n_proc = -1
+        n_proc = int(fast)
 
     if fetch:
         app.fetch()
@@ -128,8 +126,11 @@ def kraft_build(ctx, verbose=False, workdir=None, fetch=True, prepare=True,
 )
 @click.option(
     '--fast', '-j', 'fast',
-    help='Use all CPU cores to build the application.',
-    is_flag=True
+    help='Use more CPU cores to build the application.',
+    type=int,
+    is_flag=False,
+    flag_value=-1,
+    default=1
 )
 @click.option(
     '--force', '-F', 'force_build',

--- a/kraft/cmd/up.py
+++ b/kraft/cmd/up.py
@@ -133,8 +133,11 @@ from kraft.logger import logger
 )
 @click.option(
     '--fast', '-j', 'fast',
-    help='Use all CPU cores to build the application.',
-    is_flag=True
+    help='Use more CPU cores to build the application.',
+    type=int,
+    is_flag=False,
+    flag_value=-1,
+    default=1
 )
 @click.option(
     '--with-makefile', '-M', 'create_makefile',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 atpbar >= 1.0.0
 cached_property >= 1.5.1
 # Required pypi modules
-click >= 7.0
+click >= 8.1
 click-log >= 0.3.2
 colorama >= 0.4.3
 cookiecutter >= 1.7.0


### PR DESCRIPTION
The `-j, --fast` option only passed `-j -1` to make, which led to a lot of jobs being created increasing the load on the system.

This commit considers the argument passed to the `-j, --fast` command and passes it to make. If no argument is given, it will pass -1.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>